### PR TITLE
Define the Phase 1 source bootstrap plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ data/index/
 *.faiss
 *.hnswlib
 
+# Project-local git worktrees
+.worktrees/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The system is intended to work against a curated corpus rather than open web sea
 
 Initial source priorities:
 
+- `srd_35` as the bootstrap admitted source slice
 - official D&D 3.5e rules text that the user lawfully owns or maintains for personal use
 - structured supplementary source material added intentionally to the corpus
 - future errata or FAQ material, if added, as separately labeled sources
@@ -144,4 +145,4 @@ Avoid:
 
 ## Next step
 
-The immediate next step is to validate one real source slice with a small gold question set, then let the contracts tighten around that vertical slice before larger infrastructure choices are made.
+The immediate next step is to freeze the bootstrap source plan around `srd_35`, then build the first gold question set and ingestion spike against that admitted slice.

--- a/configs/source_registry.yaml
+++ b/configs/source_registry.yaml
@@ -12,8 +12,9 @@ sources:
     status: planned_later
     priority: secondary
     notes: >-
-      Planned for a later Phase 1 expansion after the bootstrap slice proves the source,
-      locator, and ingestion contracts on srd_35.
+      Deliberately demoted from the earlier bootstrap-primary assumption to a later
+      Phase 1 expansion. srd_35 is the current bootstrap slice because it is a
+      cleaner first source for source, locator, and ingestion-contract validation.
 
   - source_id: dmg_35
     title: Dungeon Master's Guide

--- a/configs/source_registry.yaml
+++ b/configs/source_registry.yaml
@@ -8,7 +8,7 @@ sources:
     title: Player's Handbook
     edition: 3.5e
     source_type: core_rulebook
-    authority: official
+    authority_level: official
     status: planned_later
     priority: secondary
     notes: >-
@@ -20,7 +20,7 @@ sources:
     title: Dungeon Master's Guide
     edition: 3.5e
     source_type: core_rulebook
-    authority: official
+    authority_level: official
     status: planned_later
     priority: secondary
     notes: >-
@@ -31,7 +31,7 @@ sources:
     title: Monster Manual
     edition: 3.5e
     source_type: core_rulebook
-    authority: official
+    authority_level: official
     status: planned_later
     priority: secondary
     notes: >-
@@ -41,8 +41,8 @@ sources:
   - source_id: srd_35
     title: System Reference Document
     edition: 3.5e
-    source_type: srd_reference
-    authority: official_reference
+    source_type: srd
+    authority_level: official_reference
     status: admitted_bootstrap
     priority: primary
     notes: >-

--- a/configs/source_registry.yaml
+++ b/configs/source_registry.yaml
@@ -9,37 +9,41 @@ sources:
     edition: 3.5e
     source_type: core_rulebook
     authority: official
-    status: planned
-    priority: primary
+    status: planned_later
+    priority: secondary
     notes: >-
-      Core rules source candidate for Phase 1.
+      Planned for a later Phase 1 expansion after the bootstrap slice proves the source,
+      locator, and ingestion contracts on srd_35.
 
   - source_id: dmg_35
     title: Dungeon Master's Guide
     edition: 3.5e
     source_type: core_rulebook
     authority: official
-    status: planned
+    status: planned_later
     priority: secondary
     notes: >-
-      Planned as a later core expansion source after initial Phase 1 corpus definition.
+      Planned as a later core expansion source after the bootstrap source plan and
+      first ingestion slice are validated.
 
   - source_id: mm_35
     title: Monster Manual
     edition: 3.5e
     source_type: core_rulebook
     authority: official
-    status: planned
+    status: planned_later
     priority: secondary
     notes: >-
-      Relevant for monster- and rules-adjacent lookups, but not required to define the initial ingestion model.
+      Relevant for monster- and rules-adjacent lookups, but deferred until after the
+      bootstrap slice is working.
 
   - source_id: srd_35
     title: System Reference Document
     edition: 3.5e
     source_type: srd_reference
     authority: official_reference
-    status: optional
-    priority: secondary
+    status: admitted_bootstrap
+    priority: primary
     notes: >-
-      Optional structured reference source if explicitly added to the Phase 1 corpus.
+      Bootstrap source for Phase 1. Use this admitted slice first for evaluation,
+      ingestion, and citation-contract validation before expanding to PHB / DMG / MM.

--- a/data/README.md
+++ b/data/README.md
@@ -6,11 +6,23 @@ This directory holds local corpus files. **Nothing here is committed to git.**
 
 ```text
 data/
-|-- raw/           Original source files as obtained (PDFs, etc.)
-|-- extracted/     Raw text extracted from source files, pre-normalization
-|-- canonical/     Normalized canonical documents (JSON, per schema)
+|-- raw/           Original source files as obtained (PDFs, etc.), organized by source_id
+|-- extracted/     Raw text extracted from source files, pre-normalization, organized by source_id
+|-- canonical/     Normalized canonical documents (JSON, per schema), organized by source_id
 |-- chunks/        Stable chunk/evidence objects ready for indexing (JSON, per schema)
 `-- index/         Derived local retrieval artifacts (FAISS, Chroma, sqlite-vec, etc.)
+```
+
+Bootstrap example:
+
+```text
+data/
+|-- raw/
+|   `-- srd_35/
+|-- extracted/
+|   `-- srd_35/
+`-- canonical/
+    `-- srd_35/
 ```
 
 ## Copyright Notice

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -24,7 +24,7 @@
 - [ ] Implement chunker
 - [ ] Choose a baseline local vector index plus one embedding model and one answer model
 - [ ] Set up vector index and embedding pipeline
-- [ ] Implement retrieval pipeline (filter -> retrieve -> threshold)
+- [ ] Implement retrieval pipeline (filter → retrieve → threshold)
 - [ ] Implement answer generation with grounding constraint
 - [ ] Implement citation rendering
 - [ ] Implement abstention behavior
@@ -46,7 +46,7 @@
 
 ## Deferred / Out of Scope
 
-- multi-edition support
-- homebrew content integration
-- public hosting or multi-user access
-- real-time web retrieval
+- Multi-edition support
+- Homebrew content integration
+- Public hosting or multi-user access
+- Real-time web retrieval

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,50 +2,51 @@
 
 > **English** | [中文](zh/roadmap.md)
 
-## Phase 0 — Design (current)
+## Phase 0 - Design (current)
 
 - [ ] Define product scope
+- [ ] Define source bootstrap plan and admission contract
 - [ ] Design corpus ingestion pipeline
 - [ ] Design chunking and retrieval pipeline
 - [ ] Define citation policy
 - [ ] Define model strategy (roles and selection criteria)
 - [ ] Define evaluation plan
-- [ ] Select one real source slice (SRD or one PHB chapter)
+- [ ] Freeze the admitted bootstrap source slice (`srd_35`)
 - [ ] Build a 20-30 question gold set for that slice
 - [ ] Align thin `source_ref` / `locator` / `answer_segments` contracts
 - [ ] Validate provisional schemas against the slice
 
-## Phase 1 — Core Implementation
+## Phase 1 - Core Implementation
 
-**Sources:** Start with one admitted source slice, then expand deliberately to PHB, DMG, MM, SRD, and later official errata / FAQ as the contracts hold up.
+**Sources:** Bootstrap with `srd_35`, then expand deliberately to PHB, DMG, MM, and later official errata / FAQ as the contracts hold up.
 
 - [ ] Implement ingestion pipeline (extraction + normalization)
 - [ ] Implement chunker
 - [ ] Choose a baseline local vector index plus one embedding model and one answer model
 - [ ] Set up vector index and embedding pipeline
-- [ ] Implement retrieval pipeline (filter → retrieve → threshold)
+- [ ] Implement retrieval pipeline (filter -> retrieve -> threshold)
 - [ ] Implement answer generation with grounding constraint
 - [ ] Implement citation rendering
 - [ ] Implement abstention behavior
-- [ ] Run evaluation against Phase 0 test set
+- [ ] Run evaluation against the Phase 0 test set
 
-## Phase 2 — Quality Improvements
+## Phase 2 - Quality Improvements
 
 - [ ] Add reranker
 - [ ] Expand source corpus (official supplements)
 - [ ] Improve chunking for complex layouts (tables, multi-column)
-- [ ] Add errata/FAQ override layer
-- [ ] Extend evaluation set
+- [ ] Add errata / FAQ override layer
+- [ ] Extend the evaluation set
 
-## Phase 3 — Interface
+## Phase 3 - Interface
 
 - [ ] Define target interface (CLI, Discord bot, web UI)
-- [ ] Implement chosen interface
+- [ ] Implement the chosen interface
 - [ ] Add query logging for offline analysis
 
 ## Deferred / Out of Scope
 
-- Multi-edition support
-- Homebrew content integration
-- Public hosting or multi-user access
-- Real-time web retrieval
+- multi-edition support
+- homebrew content integration
+- public hosting or multi-user access
+- real-time web retrieval

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 > **English** | [中文](zh/roadmap.md)
 
-## Phase 0 - Design (current)
+## Phase 0 — Design (current)
 
 - [ ] Define product scope
 - [ ] Define source bootstrap plan and admission contract
@@ -16,7 +16,7 @@
 - [ ] Align thin `source_ref` / `locator` / `answer_segments` contracts
 - [ ] Validate provisional schemas against the slice
 
-## Phase 1 - Core Implementation
+## Phase 1 — Core Implementation
 
 **Sources:** Bootstrap with `srd_35`, then expand deliberately to PHB, DMG, MM, and later official errata / FAQ as the contracts hold up.
 
@@ -30,7 +30,7 @@
 - [ ] Implement abstention behavior
 - [ ] Run evaluation against the Phase 0 test set
 
-## Phase 2 - Quality Improvements
+## Phase 2 — Quality Improvements
 
 - [ ] Add reranker
 - [ ] Expand source corpus (official supplements)
@@ -38,7 +38,7 @@
 - [ ] Add errata / FAQ override layer
 - [ ] Extend the evaluation set
 
-## Phase 3 - Interface
+## Phase 3 — Interface
 
 - [ ] Define target interface (CLI, Discord bot, web UI)
 - [ ] Implement the chosen interface

--- a/docs/source_bootstrap_plan.md
+++ b/docs/source_bootstrap_plan.md
@@ -45,7 +45,7 @@ The admission rule for the bootstrap slice is:
 - the source must be intentionally selected in the registry
 - the source must be inside the D&D 3.5e boundary
 - the source must have clear provenance
-- the source must have explicit `source_type`, `authority`, and `edition`
+- the source must have explicit `source_type`, `authority_level`, and `edition`
 - the source must be stable enough to reproduce ingestion later
 
 For bootstrap work, the project should reject or defer a source if:
@@ -78,7 +78,7 @@ Every admitted bootstrap source should preserve at least:
 - source title
 - `edition`
 - `source_type`
-- `authority`
+- `authority_level`
 - a note describing the raw artifact or upstream source form
 - enough locator information to support later citation
 - notes about known extraction or structural caveats

--- a/docs/source_bootstrap_plan.md
+++ b/docs/source_bootstrap_plan.md
@@ -1,0 +1,152 @@
+# Source Bootstrap Plan
+
+> **English**
+
+## 1. Purpose
+
+This document defines the **Phase 1 bootstrap source plan** for the D&D 3.5e Knowledge Chatbot.
+
+It answers one narrow but blocking question:
+
+> what is the first admitted corpus slice that later evaluation, ingestion, chunking, and retrieval work should be built against?
+
+This is not a plan for the entire long-term corpus. It is the admission contract for the first source set only.
+
+## 2. Bootstrap decision
+
+Phase 1 bootstrap should start with **`srd_35` only**.
+
+This means:
+
+- the first admitted source slice is the D&D 3.5e SRD
+- the first gold evaluation set should be written against SRD-covered questions
+- the first ingestion spike should target SRD material, not PHB / DMG / MM PDFs
+
+Core rulebooks remain in the registry, but they are **not part of the bootstrap admission set** yet.
+
+## 3. Why `srd_35` comes first
+
+`srd_35` is the best bootstrap source because it is the lowest-friction way to validate the product contract.
+
+Compared with a PDF-first bootstrap, SRD-first gives the project:
+
+- clearer source structure
+- lower extraction noise
+- easier locator design for non-paginated content
+- a faster path to testing grounded answers, citation rendering, and abstain behavior
+
+The project should prove that the contracts work on one structured admitted source before it takes on OCR quality, page mapping, and layout recovery from scanned books.
+
+## 4. Admission states
+
+Phase 1 should use these source admission states in the registry:
+
+- `admitted_bootstrap`
+  The source is part of the first admitted corpus slice and may be used for evaluation and ingestion spikes now.
+- `planned_later`
+  The source is intentionally in scope for a later Phase 1 expansion, but it is not part of the bootstrap slice yet.
+- `excluded_phase1`
+  The source is intentionally out of scope for the current phase.
+
+This state should answer a practical question:
+
+> may this source enter the corpus right now?
+
+## 5. Admission contract
+
+A source may enter the bootstrap corpus only if all of the following are true:
+
+- it is intentionally selected in the registry
+- it is within the D&D 3.5e boundary
+- its provenance is known well enough to cite and audit later
+- its source type and authority are explicit
+- its raw input form is stable enough to reproduce ingestion later
+
+For bootstrap work, a source should be rejected or deferred if:
+
+- edition identity is ambiguous
+- provenance is missing or weak
+- the source is unofficial commentary, fan material, or AI-generated summary text
+- the extraction path is so noisy that it prevents contract validation
+
+## 6. Provenance requirements
+
+Every admitted bootstrap source should preserve at least:
+
+- `source_id`
+- source title
+- `edition`
+- `source_type`
+- `authority`
+- a note describing the raw artifact or upstream source form
+- enough locator information to support later citation
+- notes about known extraction or structural caveats
+
+For `srd_35`, the bootstrap expectation is source-native structure first, page references only if a later admitted source provides them.
+
+## 7. Edition writing rule
+
+The bootstrap set should write the edition label consistently as:
+
+- `3.5e`
+
+Do not mix:
+
+- `3.5`
+- `v3.5`
+- `D&D 3.5`
+
+within the structured metadata contract.
+
+## 8. Bootstrap directory layout
+
+Bootstrap corpus files should be organized by `source_id`.
+
+Expected layout:
+
+```text
+data/
+|-- raw/
+|   `-- srd_35/
+|-- extracted/
+|   `-- srd_35/
+`-- canonical/
+    `-- srd_35/
+```
+
+Guidelines:
+
+- `data/raw/srd_35/` holds the raw admitted source artifact or curated source snapshot
+- `data/extracted/srd_35/` holds extracted text or intermediate structured dumps
+- `data/canonical/srd_35/` holds canonical document JSON outputs
+
+This keeps the bootstrap slice easy to inspect and avoids mixing later sources into the first ingestion pass.
+
+## 9. Bootstrap scope boundary
+
+The bootstrap source plan does **not** mean SRD is the only source the project will ever support.
+
+It means only this:
+
+- the first vertical slice uses `srd_35`
+- the first gold questions should be answerable from `srd_35`
+- the first ingestion spike should prove the canonical contract on `srd_35`
+
+PHB, DMG, and MM should remain registered as later planned sources, not silently admitted into the first slice.
+
+## 10. Expansion trigger
+
+The project should expand beyond `srd_35` only after the bootstrap slice has passed a basic reality check:
+
+- the gold set exists
+- the ingestion spike has produced inspectable canonical documents
+- citation locators work for real examples
+- retrieval and answer behavior are stable enough to expose the next real bottleneck
+
+At that point, the likely next expansion is one narrow PHB slice rather than all core books at once.
+
+## 11. Summary
+
+In one sentence:
+
+> Phase 1 bootstrap should admit `srd_35` first, use it to validate the first evaluation and ingestion slice, and defer PHB / DMG / MM until the source contract has been proven on that smaller corpus.

--- a/docs/source_bootstrap_plan.md
+++ b/docs/source_bootstrap_plan.md
@@ -1,75 +1,76 @@
 # Source Bootstrap Plan
 
-> **English**
+> **English** | [中文](zh/source_bootstrap_plan.md)
 
-## 1. Purpose
+## 1. Goal
 
-This document defines the **Phase 1 bootstrap source plan** for the D&D 3.5e Knowledge Chatbot.
+Define the first admitted corpus slice for Phase 1 so later evaluation, ingestion, chunking, and retrieval work all target the same real source set.
 
-It answers one narrow but blocking question:
+The immediate question is simple:
 
-> what is the first admitted corpus slice that later evaluation, ingestion, chunking, and retrieval work should be built against?
+> what source should enter the corpus first, under what admission rules, and in what directory layout?
 
-This is not a plan for the entire long-term corpus. It is the admission contract for the first source set only.
+## 2. Scope And Non-Goals
 
-## 2. Bootstrap decision
+### In scope
 
-Phase 1 bootstrap should start with **`srd_35` only**.
+- choosing the Phase 1 bootstrap source
+- defining the bootstrap admission rule
+- defining the minimum provenance bar for admitted sources
+- defining the edition-writing rule for the bootstrap set
+- defining the first-pass layout under `data/raw/`, `data/extracted/`, and `data/canonical/`
 
-This means:
+### Non-goals
+
+- choosing the full long-term corpus
+- deciding the final extraction toolchain
+- admitting all core rulebooks at once
+- solving later errata and FAQ layering
+- deciding final chunking or retrieval implementation details
+
+## 3. Proposed Design
+
+Phase 1 bootstrap should admit **`srd_35` only**.
+
+That means:
 
 - the first admitted source slice is the D&D 3.5e SRD
 - the first gold evaluation set should be written against SRD-covered questions
-- the first ingestion spike should target SRD material, not PHB / DMG / MM PDFs
+- the first ingestion spike should target SRD material first, not PHB / DMG / MM PDFs
 
-Core rulebooks remain in the registry, but they are **not part of the bootstrap admission set** yet.
+Core rulebooks remain in the registry, but they are deferred to a later expansion after the bootstrap slice has proven the basic source, locator, and ingestion contracts.
 
-## 3. Why `srd_35` comes first
+The admission rule for the bootstrap slice is:
 
-`srd_35` is the best bootstrap source because it is the lowest-friction way to validate the product contract.
+- the source must be intentionally selected in the registry
+- the source must be inside the D&D 3.5e boundary
+- the source must have clear provenance
+- the source must have explicit `source_type`, `authority`, and `edition`
+- the source must be stable enough to reproduce ingestion later
 
-Compared with a PDF-first bootstrap, SRD-first gives the project:
-
-- clearer source structure
-- lower extraction noise
-- easier locator design for non-paginated content
-- a faster path to testing grounded answers, citation rendering, and abstain behavior
-
-The project should prove that the contracts work on one structured admitted source before it takes on OCR quality, page mapping, and layout recovery from scanned books.
-
-## 4. Admission states
-
-Phase 1 should use these source admission states in the registry:
-
-- `admitted_bootstrap`
-  The source is part of the first admitted corpus slice and may be used for evaluation and ingestion spikes now.
-- `planned_later`
-  The source is intentionally in scope for a later Phase 1 expansion, but it is not part of the bootstrap slice yet.
-- `excluded_phase1`
-  The source is intentionally out of scope for the current phase.
-
-This state should answer a practical question:
-
-> may this source enter the corpus right now?
-
-## 5. Admission contract
-
-A source may enter the bootstrap corpus only if all of the following are true:
-
-- it is intentionally selected in the registry
-- it is within the D&D 3.5e boundary
-- its provenance is known well enough to cite and audit later
-- its source type and authority are explicit
-- its raw input form is stable enough to reproduce ingestion later
-
-For bootstrap work, a source should be rejected or deferred if:
+For bootstrap work, the project should reject or defer a source if:
 
 - edition identity is ambiguous
 - provenance is missing or weak
-- the source is unofficial commentary, fan material, or AI-generated summary text
+- the material is unofficial commentary, fan content, or AI-generated summary text
 - the extraction path is so noisy that it prevents contract validation
 
-## 6. Provenance requirements
+## 4. Data Model Or Schema
+
+### 4.1 Registry state model
+
+Bootstrap source admission should use these states:
+
+- `admitted_bootstrap`
+  The source is in the first admitted corpus slice and may be used now.
+- `planned_later`
+  The source is intentionally in scope for a later Phase 1 expansion, but not yet admitted to the bootstrap slice.
+- `excluded_phase1`
+  The source is intentionally out of scope for the current phase.
+
+No source currently uses `excluded_phase1`. The state is reserved so later explicit exclusions do not need a new vocabulary.
+
+### 4.2 Provenance fields
 
 Every admitted bootstrap source should preserve at least:
 
@@ -82,9 +83,9 @@ Every admitted bootstrap source should preserve at least:
 - enough locator information to support later citation
 - notes about known extraction or structural caveats
 
-For `srd_35`, the bootstrap expectation is source-native structure first, page references only if a later admitted source provides them.
+For `srd_35`, the bootstrap expectation is source-native structure first. Page references become mandatory only when later admitted sources actually provide them.
 
-## 7. Edition writing rule
+### 4.3 Edition writing rule
 
 The bootstrap set should write the edition label consistently as:
 
@@ -96,13 +97,11 @@ Do not mix:
 - `v3.5`
 - `D&D 3.5`
 
-within the structured metadata contract.
+inside the structured metadata contract.
 
-## 8. Bootstrap directory layout
+### 4.4 Directory layout
 
 Bootstrap corpus files should be organized by `source_id`.
-
-Expected layout:
 
 ```text
 data/
@@ -120,33 +119,66 @@ Guidelines:
 - `data/extracted/srd_35/` holds extracted text or intermediate structured dumps
 - `data/canonical/srd_35/` holds canonical document JSON outputs
 
-This keeps the bootstrap slice easy to inspect and avoids mixing later sources into the first ingestion pass.
+## 5. Key Decisions
 
-## 9. Bootstrap scope boundary
+### Bootstrap with `srd_35`
 
-The bootstrap source plan does **not** mean SRD is the only source the project will ever support.
+`srd_35` is the first admitted source because it is the lowest-friction way to validate the product contract.
 
-It means only this:
+Compared with a PDF-first bootstrap, SRD-first gives the project:
 
-- the first vertical slice uses `srd_35`
-- the first gold questions should be answerable from `srd_35`
-- the first ingestion spike should prove the canonical contract on `srd_35`
+- clearer source structure
+- lower extraction noise
+- easier locator design for non-paginated content
+- a faster path to testing grounded answers, citation rendering, and abstain behavior
 
-PHB, DMG, and MM should remain registered as later planned sources, not silently admitted into the first slice.
+### Defer PHB / DMG / MM instead of admitting them immediately
 
-## 10. Expansion trigger
+The project should prove the contracts on one structured admitted source before it takes on OCR quality, page mapping, and layout recovery from scanned books.
 
-The project should expand beyond `srd_35` only after the bootstrap slice has passed a basic reality check:
+### Keep `excluded_phase1` even though it is unused today
 
-- the gold set exists
-- the ingestion spike has produced inspectable canonical documents
-- citation locators work for real examples
-- retrieval and answer behavior are stable enough to expose the next real bottleneck
+The vocabulary is still useful. It prevents later ad hoc wording when the project needs to record a deliberate exclusion.
 
-At that point, the likely next expansion is one narrow PHB slice rather than all core books at once.
+## 6. Alternatives Considered
 
-## 11. Summary
+### Alternative A: bootstrap with one PHB chapter
 
-In one sentence:
+This would test book-style page citations earlier.
 
-> Phase 1 bootstrap should admit `srd_35` first, use it to validate the first evaluation and ingestion slice, and defer PHB / DMG / MM until the source contract has been proven on that smaller corpus.
+Why not now:
+
+- it introduces extraction and layout noise too early
+- it makes locator and ingestion validation depend on PDF quality before the base contract is proven
+
+### Alternative B: bootstrap with multiple narrow sources at once
+
+This would broaden coverage sooner.
+
+Why not now:
+
+- it adds source-policy ambiguity before the first admission rule is stable
+- it makes failures harder to localize
+
+### Alternative C: admit all core books immediately
+
+This could look closer to the eventual product corpus.
+
+Why not now:
+
+- it is too much surface area for the first contract-validation step
+- it increases the risk of hiding source and locator problems under corpus size
+
+## 7. Risks And Open Questions
+
+- SRD structure is cleaner than PDF rulebooks, but it may still expose locator or extraction edge cases.
+- SRD-first means the bootstrap slice will not test page-based citations yet.
+- Some later Phase 1 questions may require PHB-only material, so the gold set must stay honest about SRD coverage.
+- The next admitted source after `srd_35` is still open. A narrow PHB slice is the current likely candidate, but not yet a locked decision.
+
+## 8. Next Steps
+
+- align the source registry to mark `srd_35` as `admitted_bootstrap`
+- build the first gold evaluation set against SRD-covered questions
+- run the first ingestion spike against `data/raw/srd_35/`
+- expand beyond `srd_35` only after the bootstrap slice proves the contract is stable enough to carry a noisier source

--- a/docs/zh/source_bootstrap_plan.md
+++ b/docs/zh/source_bootstrap_plan.md
@@ -1,0 +1,182 @@
+# 初始来源引导方案
+
+> [English](../source_bootstrap_plan.md) | **中文**
+
+## 1. 目标
+
+定义 Phase 1 的第一批准入语料，让后续的评测、摄入、分块与检索都围绕同一批真实来源展开。
+
+这份文档要解决的问题是：
+
+> 第一批 corpus 先收什么、按什么准入、目录怎么落地？
+
+## 2. 范围与非目标
+
+### 范围内
+
+- 选定 Phase 1 的 bootstrap source
+- 定义第一批来源的准入规则
+- 定义最低 provenance 要求
+- 定义 bootstrap 集合的 edition 写法
+- 定义 `data/raw/`、`data/extracted/`、`data/canonical/` 的首版目录布局
+
+### 非目标
+
+- 一次性确定长期完整语料范围
+- 决定最终 extraction 工具链
+- 一次性准入所有核心规则书
+- 解决后续 errata / FAQ 覆盖策略
+- 决定最终 chunking 或 retrieval 的实现细节
+
+## 3. 方案
+
+Phase 1 的 bootstrap 应先只准入 **`srd_35`**。
+
+这意味着：
+
+- 第一批 admitted source slice 是 D&D 3.5e SRD
+- 第一版 gold evaluation set 先围绕 SRD 能覆盖的问题编写
+- 第一轮 ingestion spike 先处理 SRD，而不是直接从 PHB / DMG / MM PDF 开始
+
+PHB、DMG、MM 仍然保留在 registry 中，但在 bootstrap 阶段先不准入，等第一条真实链路验证完 source、locator、ingestion contract 之后再扩展。
+
+bootstrap 阶段的准入规则是：
+
+- 来源必须在 registry 中被明确选中
+- 来源必须严格属于 D&D 3.5e 边界
+- 来源必须有清晰 provenance
+- 来源必须显式标注 `source_type`、`authority`、`edition`
+- 来源的原始输入形式必须稳定，可复现后续摄入
+
+下列情况应拒绝或延后：
+
+- edition 身份不清
+- provenance 缺失或过弱
+- 来源是非官方评论、同人内容或 AI 生成摘要
+- extraction 路径噪声过大，已经妨碍 contract 验证
+
+## 4. 数据模型或模式
+
+### 4.1 Registry 状态
+
+bootstrap 准入应使用以下状态：
+
+- `admitted_bootstrap`
+  已进入第一批准入语料，现在就可以用于评测与 ingestion spike。
+- `planned_later`
+  明确属于后续 Phase 1 扩展范围，但还没进入 bootstrap slice。
+- `excluded_phase1`
+  明确不在当前阶段范围内。
+
+目前还没有来源使用 `excluded_phase1`。这个状态先保留，供后续显式排除来源时直接使用。
+
+### 4.2 Provenance 字段
+
+每个 bootstrap 来源至少应保留：
+
+- `source_id`
+- 来源标题
+- `edition`
+- `source_type`
+- `authority`
+- 描述原始制品或上游形式的说明
+- 足以支撑后续 citation 的 locator 信息
+- 已知 extraction / structure caveat 说明
+
+对于 `srd_35`，bootstrap 阶段优先保留 source-native 结构；页码引用等到后续准入真的带分页来源时再强化。
+
+### 4.3 Edition 写法
+
+bootstrap 集合中的 edition 统一写成：
+
+- `3.5e`
+
+不要在结构化元数据里混用：
+
+- `3.5`
+- `v3.5`
+- `D&D 3.5`
+
+### 4.4 目录布局
+
+bootstrap corpus 先按 `source_id` 组织：
+
+```text
+data/
+|-- raw/
+|   `-- srd_35/
+|-- extracted/
+|   `-- srd_35/
+`-- canonical/
+    `-- srd_35/
+```
+
+含义如下：
+
+- `data/raw/srd_35/` 放原始来源制品或整理后的来源快照
+- `data/extracted/srd_35/` 放提取后的文本或中间结构化结果
+- `data/canonical/srd_35/` 放 canonical document JSON
+
+## 5. 关键决策
+
+### 先用 `srd_35`
+
+之所以先选 `srd_35`，是因为它最适合低成本验证产品 contract。
+
+和直接从 PDF 起步相比，SRD-first 有这些好处：
+
+- 结构更清晰
+- extraction 噪声更低
+- 更容易先把非分页 locator 设计跑通
+- 更快看到 grounded answer、citation rendering、abstain 行为是否成立
+
+### PHB / DMG / MM 先延后
+
+项目应先在一个结构更干净的真实来源上证明 contract 成立，再去面对 OCR、页码映射、复杂版式恢复这些问题。
+
+### 保留 `excluded_phase1`
+
+虽然当前还没用到，但这个状态是有意义的。以后需要显式排除某类来源时，不必再临时发明新词。
+
+## 6. 备选方案
+
+### 方案 A：先用一个 PHB 章节
+
+优点是更早测试书籍型页码引用。
+
+这次没选它，因为：
+
+- 它太早把版式与提取噪声引进来了
+- 会让 locator 和 ingestion 验证过度依赖 PDF 质量
+
+### 方案 B：一开始就并行准入多种窄来源
+
+优点是覆盖面更快变宽。
+
+这次没选它，因为：
+
+- source policy 还没稳定时，多来源会放大歧义
+- 失败后更难判断到底是哪一层坏了
+
+### 方案 C：一次性准入所有核心规则书
+
+优点是看起来更接近最终产品。
+
+这次没选它，因为：
+
+- 第一轮 contract 验证的面太大
+- 容易把 source 和 locator 的问题埋在 corpus 规模里
+
+## 7. 风险与开放问题
+
+- SRD 的结构虽然比 PDF 干净，但仍可能暴露 locator 或 extraction 边角问题。
+- SRD-first 还不能真正测试页码型 citation。
+- 后续有些问题可能只存在于 PHB 而不在 SRD 中，所以 gold set 需要诚实反映 SRD 覆盖边界。
+- `srd_35` 之后扩展哪个来源仍是开放问题。目前最可能的是一个窄 PHB slice，但还不是锁定决策。
+
+## 8. 下一步
+
+- 在 source registry 中把 `srd_35` 标成 `admitted_bootstrap`
+- 围绕 SRD 可覆盖问题编写第一版 gold evaluation set
+- 对 `data/raw/srd_35/` 跑第一轮 ingestion spike
+- 只有当 bootstrap slice 证明 contract 足够稳时，才扩展到 `srd_35` 之外的来源

--- a/docs/zh/source_bootstrap_plan.md
+++ b/docs/zh/source_bootstrap_plan.md
@@ -45,7 +45,7 @@ bootstrap 阶段的准入规则是：
 - 来源必须在 registry 中被明确选中
 - 来源必须严格属于 D&D 3.5e 边界
 - 来源必须有清晰 provenance
-- 来源必须显式标注 `source_type`、`authority`、`edition`
+- 来源必须显式标注 `source_type`、`authority_level`、`edition`
 - 来源的原始输入形式必须稳定，可复现后续摄入
 
 下列情况应拒绝或延后：
@@ -78,7 +78,7 @@ bootstrap 准入应使用以下状态：
 - 来源标题
 - `edition`
 - `source_type`
-- `authority`
+- `authority_level`
 - 描述原始制品或上游形式的说明
 - 足以支撑后续 citation 的 locator 信息
 - 已知 extraction / structure caveat 说明


### PR DESCRIPTION
## Summary
- add a dedicated Phase 1 bootstrap source plan that fixes the first admitted source slice to `srd_35`
- define bootstrap admission states and update `source_registry.yaml` so SRD is admitted now while PHB / DMG / MM remain planned for later
- align the roadmap, repository README, and `data/README.md` with the bootstrap decision and first-pass `data/raw/`, `data/extracted/`, and `data/canonical/` layout

## Verification
- ran `git diff --check` in the issue worktree with no patch errors
- no project test suite exists in this repo for this doc-only change

Closes #7