### PR TITLE
Unify metadata vocabulary and locator contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ Do not collapse ingestion and chunking into one conceptual step unless explicitl
 Whenever proposing schemas or architecture, distinguish at least:
 `source_id`, `source_type`, `title`, `edition`, `authority_level`, `page range`, `section_path`, `version or checksum`, `chunk_id`, `citation_anchor`
 
-Default source categories: `official_rulebook`, `official_errata`, `official_faq`, `srd`, `commentary`, `homebrew`, `personal_note`
+Default source categories: `core_rulebook`, `supplement_rulebook`, `errata_document`, `faq_document`, `srd`, `curated_commentary`, `personal_note`
 
 ## Retrieval and Citation Principles
 

--- a/configs/bootstrap_sources/srd_35.manifest.json
+++ b/configs/bootstrap_sources/srd_35.manifest.json
@@ -32,7 +32,7 @@
     "extracted_root": "data/extracted/srd_35",
     "canonical_root": "data/canonical/srd_35"
   },
-  "locator": {
+  "locator_policy": {
     "style": "source_location",
     "bootstrap_rule": "Use source-native file names plus section or entry paths. Do not invent page references for this source."
   },

--- a/docs/metadata_contract.md
+++ b/docs/metadata_contract.md
@@ -1,0 +1,109 @@
+# Metadata Contract
+
+## Goal
+
+Define one shared metadata vocabulary for source identity and locator semantics so source configs, schemas, and examples compose without field translation.
+
+## Shared Vocabulary
+
+### Core fields
+
+- `source_id`
+  Stable snake_case source identifier such as `srd_35` or `phb_35`.
+- `edition`
+  Edition label. Use `3.5e` for Phase 1.
+- `source_type`
+  Source category enum:
+  - `core_rulebook`
+  - `supplement_rulebook`
+  - `errata_document`
+  - `faq_document`
+  - `srd`
+  - `curated_commentary`
+  - `personal_note`
+- `authority_level`
+  Source authority enum:
+  - `official`
+  - `official_reference`
+  - `curated_secondary`
+  - `personal_note`
+
+### Locator semantics
+
+- `locator`
+  Evidence-level location object attached to canonical documents, chunks, and citations.
+- `locator_policy`
+  Source-level locator guidance stored in source manifests and similar source-policy configs.
+
+`locator_policy` and `locator` are intentionally separate:
+- `locator_policy` defines how a source should be located.
+- `locator` records the concrete location instance for a specific evidence object.
+
+## Evidence Locator Shape
+
+`locator` supports both paginated and non-paginated sources.
+
+Expected fields (when available):
+- `page_range`
+- `section_path`
+- `entry_id`
+- `entry_title`
+- `source_location`
+
+At least one of those must be present.
+
+## Examples
+
+### Non-paginated source example (`srd_35`)
+
+```json
+{
+  "source_ref": {
+    "source_id": "srd_35",
+    "title": "System Reference Document",
+    "edition": "3.5e",
+    "source_type": "srd",
+    "authority_level": "official_reference"
+  },
+  "locator": {
+    "section_path": ["Classes", "Fighter", "Class Features", "Bonus Feats"],
+    "entry_title": "Bonus Feats",
+    "source_location": "ClassesI.rtf > Bonus Feats"
+  }
+}
+```
+
+### Paginated source example (`phb_35`)
+
+```json
+{
+  "source_ref": {
+    "source_id": "phb_35",
+    "title": "Player's Handbook",
+    "edition": "3.5e",
+    "source_type": "core_rulebook",
+    "authority_level": "official"
+  },
+  "locator": {
+    "section_path": ["Chapter 3: Classes", "Fighter", "Class Features", "Bonus Feats"],
+    "entry_title": "Bonus Feats",
+    "page_range": {
+      "start": 37,
+      "end": 38
+    }
+  }
+}
+```
+
+## Contract Application
+
+This contract is the normalization target for:
+
+- `configs/source_registry.yaml`
+- `configs/bootstrap_sources/srd_35.manifest.json`
+- `schemas/common.schema.json`
+- `examples/canonical_document.example.json`
+- `examples/chunk.example.json`
+- `examples/answer_with_citations.example.json`
+
+If future schema updates conflict with this document, this document should be updated first or in the same PR.

--- a/docs/zh/metadata_contract.md
+++ b/docs/zh/metadata_contract.md
@@ -1,21 +1,21 @@
-# Metadata Contract
+# 元数据契约
 
-> **English** | [中文](zh/metadata_contract.md)
+> [English](../metadata_contract.md) | **中文**
 
-## Goal
+## 目标
 
-Define one shared metadata vocabulary for source identity and locator semantics so source configs, schemas, and examples compose without field translation.
+定义一套共享元数据词汇，用于统一来源配置、schema 与 examples，避免字段翻译层。
 
-## Shared Vocabulary
+## 共享词汇
 
-### Core fields
+### 核心字段
 
 - `source_id`
-  Stable snake_case source identifier such as `srd_35` or `phb_35`.
+  稳定的 snake_case 来源标识，例如 `srd_35`、`phb_35`。
 - `edition`
-  Edition label. Use `3.5e` for Phase 1.
+  版本标签。Phase 1 统一使用 `3.5e`。
 - `source_type`
-  Source category enum:
+  来源类型枚举：
   - `core_rulebook`
   - `supplement_rulebook`
   - `errata_document`
@@ -24,39 +24,39 @@ Define one shared metadata vocabulary for source identity and locator semantics 
   - `curated_commentary`
   - `personal_note`
 - `authority_level`
-  Source authority enum:
+  权威级别枚举：
   - `official`
   - `official_reference`
   - `curated_secondary`
   - `personal_note`
 
-### Locator semantics
+### Locator 语义
 
 - `locator`
-  Evidence-level location object attached to canonical documents, chunks, and citations.
+  证据对象级定位信息，挂在 canonical document、chunk、citation 上。
 - `locator_policy`
-  Source-level locator guidance stored in source manifests and similar source-policy configs.
+  来源级定位策略，挂在 manifest / registry 等来源策略对象上。
 
-`locator_policy` and `locator` are intentionally separate:
-- `locator_policy` defines how a source should be located.
-- `locator` records the concrete location instance for a specific evidence object.
+两者边界：
+- `locator_policy` 用于说明某个来源“应该如何定位”。
+- `locator` 用于记录某个证据对象“实际定位到哪里”。
 
-## Evidence Locator Shape
+## 证据级 locator 形状
 
-`locator` supports both paginated and non-paginated sources.
+`locator` 必须同时支持分页与非分页来源。
 
-Expected fields (when available):
+可用字段：
 - `page_range`
 - `section_path`
 - `entry_id`
 - `entry_title`
 - `source_location`
 
-At least one of those must be present.
+至少要有一个字段存在。
 
-## Examples
+## 示例
 
-### Non-paginated source example (`srd_35`)
+### 非分页来源示例（`srd_35`）
 
 ```json
 {
@@ -75,7 +75,7 @@ At least one of those must be present.
 }
 ```
 
-### Paginated source example (`phb_35`)
+### 分页来源示例（`phb_35`）
 
 ```json
 {
@@ -97,9 +97,9 @@ At least one of those must be present.
 }
 ```
 
-## Contract Application
+## 契约落点
 
-This contract is the normalization target for:
+本契约适用于以下文件：
 
 - `configs/source_registry.yaml`
 - `configs/bootstrap_sources/srd_35.manifest.json`
@@ -108,4 +108,4 @@ This contract is the normalization target for:
 - `examples/chunk.example.json`
 - `examples/answer_with_citations.example.json`
 
-If future schema updates conflict with this document, this document should be updated first or in the same PR.
+若未来 schema 与本文冲突，应先更新本文，或在同一 PR 中同时更新。

--- a/examples/answer_with_citations.example.json
+++ b/examples/answer_with_citations.example.json
@@ -36,7 +36,7 @@
         "entry_title": "Bonus Feats",
         "source_location": "ClassesI.rtf > Bonus Feats > paragraph 1"
       },
-      "excerpt": "At 1st level, a fighter gets a bonus combat-oriented feat... The fighter gains an additional bonus feat at 2nd level and every two fighter levels thereafter (4th, 6th, 8th, 10th, 12th, 14th, 16th, 18th, and 20th)."
+      "excerpt": "At 1st level, a fighter gets a bonus combat-oriented feat. The fighter gains an additional bonus feat at 2nd level and every two fighter levels thereafter."
     },
     {
       "citation_id": "cit_2",

--- a/examples/answer_with_citations.example.json
+++ b/examples/answer_with_citations.example.json
@@ -18,53 +18,45 @@
   "citations": [
     {
       "citation_id": "cit_1",
-      "chunk_id": "phb_35::chapter_03::fighter::bonus_feats::chunk_1",
+      "chunk_id": "srd_35::classes::fighter::bonus_feats::chunk_1",
       "source_ref": {
-        "source_id": "phb_35",
-        "title": "Player's Handbook",
+        "source_id": "srd_35",
+        "title": "System Reference Document",
         "edition": "3.5e",
-        "source_type": "core_rulebook",
-        "authority": "official"
+        "source_type": "srd",
+        "authority_level": "official_reference"
       },
       "locator": {
         "section_path": [
-          "Chapter 3: Classes",
+          "Classes",
           "Fighter",
           "Class Features",
           "Bonus Feats"
         ],
         "entry_title": "Bonus Feats",
-        "page_range": {
-          "start": 37,
-          "end": 38
-        },
-        "source_location": "Bonus Feats paragraph 1"
+        "source_location": "ClassesI.rtf > Bonus Feats > paragraph 1"
       },
       "excerpt": "At 1st level, a fighter gets a bonus combat-oriented feat... The fighter gains an additional bonus feat at 2nd level and every two fighter levels thereafter (4th, 6th, 8th, 10th, 12th, 14th, 16th, 18th, and 20th)."
     },
     {
       "citation_id": "cit_2",
-      "chunk_id": "phb_35::chapter_03::fighter::bonus_feats::chunk_1",
+      "chunk_id": "srd_35::classes::fighter::bonus_feats::chunk_1",
       "source_ref": {
-        "source_id": "phb_35",
-        "title": "Player's Handbook",
+        "source_id": "srd_35",
+        "title": "System Reference Document",
         "edition": "3.5e",
-        "source_type": "core_rulebook",
-        "authority": "official"
+        "source_type": "srd",
+        "authority_level": "official_reference"
       },
       "locator": {
         "section_path": [
-          "Chapter 3: Classes",
+          "Classes",
           "Fighter",
           "Class Features",
           "Bonus Feats"
         ],
         "entry_title": "Bonus Feats",
-        "page_range": {
-          "start": 37,
-          "end": 38
-        },
-        "source_location": "Bonus Feats paragraph 2"
+        "source_location": "ClassesI.rtf > Bonus Feats > paragraph 2"
       },
       "excerpt": "These bonus feats must be drawn from the feats noted as fighter bonus feats. A fighter must still meet all prerequisites for a bonus feat."
     }

--- a/examples/canonical_document.example.json
+++ b/examples/canonical_document.example.json
@@ -1,28 +1,25 @@
 {
-  "document_id": "phb_35::chapter_03::fighter::bonus_feats",
+  "document_id": "srd_35::classes::fighter::bonus_feats",
   "source_ref": {
-    "source_id": "phb_35",
-    "title": "Player's Handbook",
+    "source_id": "srd_35",
+    "title": "System Reference Document",
     "edition": "3.5e",
-    "source_type": "core_rulebook",
-    "authority": "official"
+    "source_type": "srd",
+    "authority_level": "official_reference"
   },
   "locator": {
     "section_path": [
-      "Chapter 3: Classes",
+      "Classes",
       "Fighter",
       "Class Features",
       "Bonus Feats"
     ],
     "entry_title": "Bonus Feats",
-    "page_range": {
-      "start": 37,
-      "end": 38
-    }
+    "source_location": "ClassesI.rtf > Bonus Feats"
   },
-  "content": "Bonus Feats: At 1st level, a fighter gets a bonus combat-oriented feat in addition to the feat that any 1st-level character gets and the bonus feat granted to a human character. The fighter gains an additional bonus feat at 2nd level and every two fighter levels thereafter (4th, 6th, 8th, 10th, 12th, 14th, 16th, 18th, and 20th). These bonus feats must be drawn from the feats noted as fighter bonus feats. A fighter must still meet all prerequisites for a bonus feat, including ability score and base attack bonus minimums. These bonus feats are in addition to the feat that a character of any class gets from advancing levels. A fighter is not limited to the list of fighter bonus feats when choosing these other feats.",
+  "content": "Bonus Feats: At 1st level, a fighter gets a bonus combat-oriented feat. The fighter gains an additional bonus feat at 2nd level and every two fighter levels thereafter. These bonus feats must be drawn from the feats noted as fighter bonus feats, and the fighter must still meet all prerequisites.",
   "document_title": "Bonus Feats",
-  "source_checksum": "a3f2c1d4e5b6a7f8e9d0c1b2a3f4e5d6c7b8a9f0e1d2c3b4a5f6e7d8c9b0a1",
-  "source_version": "1st printing",
+  "source_checksum": "abf7b4259196cf1a0821ad46aefb8c98f3797104",
+  "source_version": "dnd35srd-archive-2016",
   "ingested_at": "2026-04-07T00:00:00Z"
 }

--- a/examples/chunk.example.json
+++ b/examples/chunk.example.json
@@ -1,26 +1,23 @@
 {
-  "chunk_id": "phb_35::chapter_03::fighter::bonus_feats::chunk_1",
-  "document_id": "phb_35::chapter_03::fighter::bonus_feats",
+  "chunk_id": "srd_35::classes::fighter::bonus_feats::chunk_1",
+  "document_id": "srd_35::classes::fighter::bonus_feats",
   "source_ref": {
-    "source_id": "phb_35",
-    "title": "Player's Handbook",
+    "source_id": "srd_35",
+    "title": "System Reference Document",
     "edition": "3.5e",
-    "source_type": "core_rulebook",
-    "authority": "official"
+    "source_type": "srd",
+    "authority_level": "official_reference"
   },
   "locator": {
     "section_path": [
-      "Chapter 3: Classes",
+      "Classes",
       "Fighter",
       "Class Features",
       "Bonus Feats"
     ],
     "entry_title": "Bonus Feats",
-    "page_range": {
-      "start": 37,
-      "end": 38
-    }
+    "source_location": "ClassesI.rtf > Bonus Feats"
   },
   "chunk_type": "class_feature",
-  "content": "Bonus Feats: At 1st level, a fighter gets a bonus combat-oriented feat in addition to the feat that any 1st-level character gets and the bonus feat granted to a human character. The fighter gains an additional bonus feat at 2nd level and every two fighter levels thereafter (4th, 6th, 8th, 10th, 12th, 14th, 16th, 18th, and 20th). These bonus feats must be drawn from the feats noted as fighter bonus feats. A fighter must still meet all prerequisites for a bonus feat, including ability score and base attack bonus minimums."
+  "content": "Bonus Feats: At 1st level, a fighter gets a bonus combat-oriented feat. The fighter gains an additional bonus feat at 2nd level and every two fighter levels thereafter. These bonus feats must be drawn from the feats noted as fighter bonus feats, and the fighter must still meet all prerequisites."
 }

--- a/schemas/common.schema.json
+++ b/schemas/common.schema.json
@@ -20,7 +20,7 @@
     },
     "sourceRef": {
       "type": "object",
-      "required": ["source_id", "title", "edition", "source_type", "authority"],
+      "required": ["source_id", "title", "edition", "source_type", "authority_level"],
       "additionalProperties": false,
       "properties": {
         "source_id": {
@@ -42,13 +42,13 @@
             "supplement_rulebook",
             "errata_document",
             "faq_document",
-            "srd_reference",
+            "srd",
             "curated_commentary",
             "personal_note"
           ],
           "description": "Source category shared across registry, ingestion, chunking, and citation layers"
         },
-        "authority": {
+        "authority_level": {
           "type": "string",
           "enum": [
             "official",


### PR DESCRIPTION
﻿## Summary
- add `docs/metadata_contract.md` to freeze shared source vocabulary and locator semantics
- align shared schema contract to `authority_level` and `source_type: srd`
- rename manifest source-level `locator` to `locator_policy`
- update canonical/chunk/answer examples to match the current bootstrap source (`srd_35`) with non-paginated source-native locators

## Validation
- parsed all schema/example/manifest JSON files successfully
- verified `canonical_document`, `chunk`, and `answer_with_citations` still reference common `sourceRef` and `locator` defs
- `python -m unittest tests.test_fetch_srd_35 -v`
- `git diff --check`

## Notes
- `configs/source_registry.yaml` is already aligned on `authority_level` and `source_type: srd` from merged PR #8, so no additional edits were required there.
- this PR intentionally excludes issue #2/#4/#5 scope.

Closes #3
