### PR TITLE
Issue #6: add Phase 1 SRD gold evaluation set

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 > **English** | [中文](zh/roadmap.md)
 
-## Phase 0 — Design (current)
+## Phase 0 - Design (current)
 
 - [ ] Define product scope
 - [x] Define source bootstrap plan and admission contract
@@ -12,11 +12,11 @@
 - [ ] Define model strategy (roles and selection criteria)
 - [ ] Define evaluation plan
 - [x] Freeze the admitted bootstrap source slice (`srd_35`)
-- [ ] Build a 20-30 question gold set for that slice
+- [x] Build a 20-30 question gold set for that slice
 - [x] Align thin `source_ref` / `locator` / `answer_segments` contracts
 - [ ] Validate provisional schemas against the slice
 
-## Phase 1 — Core Implementation
+## Phase 1 - Core Implementation
 
 **Sources:** Bootstrap with `srd_35`, then expand deliberately to PHB, DMG, MM, and later official errata / FAQ as the contracts hold up.
 
@@ -30,7 +30,7 @@
 - [ ] Implement abstention behavior
 - [ ] Run evaluation against the Phase 0 test set
 
-## Phase 2 — Quality Improvements
+## Phase 2 - Quality Improvements
 
 - [ ] Add reranker
 - [ ] Expand source corpus (official supplements)
@@ -38,7 +38,7 @@
 - [ ] Add errata / FAQ override layer
 - [ ] Extend the evaluation set
 
-## Phase 3 — Interface
+## Phase 3 - Interface
 
 - [ ] Define target interface (CLI, Discord bot, web UI)
 - [ ] Implement the chosen interface

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,46 @@
+# Evaluation Sets
+
+This directory stores hand-built evaluation datasets used for early regression checks.
+
+## Current Set
+
+- `phase1_gold.yaml`
+  - Scope: Phase 1 admitted bootstrap source slice (`srd_35`) only.
+  - Size: 30 cases.
+  - Coverage:
+    - direct lookup
+    - exception lookup
+    - named entry lookup
+    - multi-chunk support
+    - table-dependent lookup
+    - insufficient evidence / out-of-scope (abstain)
+
+## Case Contract
+
+Each case in `phase1_gold.yaml` includes:
+
+- `eval_id`
+- `question`
+- `question_type`
+- `expected_source_ids`
+- `expected_section_or_entry`
+- `expected_behavior`
+- `expected_answer_notes`
+
+`expected_behavior` is one of:
+
+- `direct_answer`
+- `supported_inference`
+- `narrow_answer`
+- `abstain`
+
+## How To Use
+
+Use this set as the default regression slice whenever retrieval, chunking, answer composition, citation format, or abstain logic changes.
+
+At minimum, a regression pass should check:
+
+1. Retrieval includes evidence from the expected source and section/entry.
+2. The answer behavior matches `expected_behavior`.
+3. Citation anchors support the claim type implied by `expected_answer_notes`.
+

--- a/evals/README.md
+++ b/evals/README.md
@@ -14,6 +14,10 @@ This directory stores hand-built evaluation datasets used for early regression c
     - multi-chunk support
     - table-dependent lookup
     - insufficient evidence / out-of-scope (abstain)
+- `phase1_gold.zh.yaml`
+  - Chinese-language counterpart of `phase1_gold.yaml`.
+  - Uses the same `eval_id`, `question_type`, and expected metadata contract.
+  - Intended for Chinese-user-facing evaluation while preserving one-to-one case mapping.
 
 ## Case Contract
 
@@ -43,4 +47,3 @@ At minimum, a regression pass should check:
 1. Retrieval includes evidence from the expected source and section/entry.
 2. The answer behavior matches `expected_behavior`.
 3. Citation anchors support the claim type implied by `expected_answer_notes`.
-

--- a/evals/phase1_gold.yaml
+++ b/evals/phase1_gold.yaml
@@ -1,0 +1,248 @@
+dataset_id: phase1_gold_v1
+dataset_version: 1
+created_on: 2026-04-11
+source_slice:
+  source_ids:
+    - srd_35
+  edition: 3.5e
+  notes: "Bootstrap gold set constrained to admitted SRD 3.5e slice."
+cases:
+  - eval_id: P1-DL-001
+    question: "When does a character provoke an attack of opportunity from movement?"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Movement"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should cite the movement-out-of-threatened-square rule."
+
+  - eval_id: P1-DL-002
+    question: "What does the total defense action do to Armor Class?"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Actions in Combat", "Total Defense"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should answer with the AC effect from Total Defense."
+
+  - eval_id: P1-DL-003
+    question: "What is the default speed for a human in combat movement terms?"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Races: Human", "Movement"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should answer from SRD race/basic movement text."
+
+  - eval_id: P1-DL-004
+    question: "Can a character take a 5-foot step if they did any other movement in the same round?"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Movement", "5-Foot Step"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should state the no-other-movement condition."
+
+  - eval_id: P1-DL-005
+    question: "What does being dazzled do?"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Condition Summary", "Dazzled"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should answer using the named condition definition."
+
+  - eval_id: P1-EX-001
+    question: "Does drinking a potion provoke an attack of opportunity?"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Use a Potion"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should handle provoking behavior for potion use specifically."
+
+  - eval_id: P1-EX-002
+    question: "Can you make attacks of opportunity while flat-footed?"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Flat-Footed"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should capture the flat-footed limitation."
+
+  - eval_id: P1-EX-003
+    question: "Does firing a ranged weapon while threatened provoke an attack of opportunity?"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Ranged Attacks"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should address the threatened-square exception behavior."
+
+  - eval_id: P1-EX-004
+    question: "Can you run in heavy armor?"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Movement", "Run", "Armor and Encumbrance"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should include the heavy-armor running restriction details."
+
+  - eval_id: P1-EX-005
+    question: "Can a helpless target make attacks of opportunity?"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Condition Summary", "Helpless", "Combat: Attacks of Opportunity"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "Likely requires combining helpless-state constraints with AoO requirements."
+
+  - eval_id: P1-NE-001
+    question: "What does the Power Attack feat allow you to trade?"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Feats: Power Attack"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should use the feat text directly."
+
+  - eval_id: P1-NE-002
+    question: "What are the attack penalties for fighting with two weapons without the Two-Weapon Fighting feat?"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Two-Weapon Fighting"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should pull penalties from the two-weapon fighting rule."
+
+  - eval_id: P1-NE-003
+    question: "How does the Dodge feat work?"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Feats: Dodge"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should include the designated-target requirement."
+
+  - eval_id: P1-NE-004
+    question: "What does Magic Missile do on a hit roll?"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Spells: Magic Missile"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should state whether an attack roll is required."
+
+  - eval_id: P1-NE-005
+    question: "What does the Cleave feat trigger on?"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Feats: Cleave"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should capture the trigger condition from the feat entry."
+
+  - eval_id: P1-MC-001
+    question: "Can you take a 5-foot step and still make a full attack?"
+    question_type: multi_chunk
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Full Attack", "Combat: Movement", "5-Foot Step"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "Needs combined reading of full-attack action and 5-foot-step rule."
+
+  - eval_id: P1-MC-002
+    question: "If a character is invisible and attacks, what combat advantages apply to that first attack?"
+    question_type: multi_chunk
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Condition Summary: Invisible", "Combat: Attack Roll Modifiers"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "Requires combining condition effects with combat modifier rules."
+
+  - eval_id: P1-MC-003
+    question: "Can you cast defensively while threatened, and what check determines success?"
+    question_type: multi_chunk
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Magic Overview: Concentration", "Casting Defensively"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "Should connect AoO risk with defensive casting concentration checks."
+
+  - eval_id: P1-MC-004
+    question: "If you use Tumble to move through threatened squares, what does it prevent and what does it not prevent?"
+    question_type: multi_chunk
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Skills: Tumble", "Combat: Attacks of Opportunity"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "Should combine skill usage limits with AoO baseline rules."
+
+  - eval_id: P1-MC-005
+    question: "Can you charge through difficult terrain?"
+    question_type: multi_chunk
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Charge", "Movement", "Terrain and Obstacles"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "Should resolve charge constraints against terrain movement rules."
+
+  - eval_id: P1-TB-001
+    question: "What Strength score carrying capacity applies to a medium load for Strength 10?"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Carrying Capacity Table", "Carrying and Exploration"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should cite the carrying-capacity table row for Strength 10."
+
+  - eval_id: P1-TB-002
+    question: "What ability modifier does an ability score of 18 provide?"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Ability Scores", "Ability Modifiers Table"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should read from the ability modifier table."
+
+  - eval_id: P1-TB-003
+    question: "What is the armor check penalty for full plate?"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Equipment", "Armor and Shields Table", "Full Plate"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should cite full plate row from armor table."
+
+  - eval_id: P1-TB-004
+    question: "What cover bonus does improved cover grant?"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat", "Cover", "Cover Table"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should return the improved cover benefit from the cover table."
+
+  - eval_id: P1-TB-005
+    question: "What size modifier applies to attack rolls for a Large creature?"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat", "Creature Size Modifiers Table"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should read attack modifier from size-modifier table."
+
+  - eval_id: P1-IE-001
+    question: "How does the warlock Eldritch Blast scale by level in D&D 3.5e?"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "Warlock class progression is not in admitted srd_35 bootstrap slice."
+
+  - eval_id: P1-IE-002
+    question: "What are Artificer infusion slots at level 5?"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "Artificer content is outside admitted slice."
+
+  - eval_id: P1-IE-003
+    question: "Can I spend inspiration to gain advantage on an attack roll?"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "Uses 5e-specific mechanics outside admitted 3.5e corpus."
+
+  - eval_id: P1-IE-004
+    question: "How many cantrips does a 5e wizard know at level 1?"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "Edition-out-of-scope query; should abstain cleanly."
+
+  - eval_id: P1-IE-005
+    question: "What does the Hexblade's Curse feature do?"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "Hexblade feature is outside admitted source boundary."

--- a/evals/phase1_gold.yaml
+++ b/evals/phase1_gold.yaml
@@ -27,7 +27,7 @@ cases:
     question: "What is the default speed for a human in combat movement terms?"
     question_type: direct_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Races: Human", "Movement"]
+    expected_section_or_entry: ["Races.rtf", "Races", "Humans"]
     expected_behavior: direct_answer
     expected_answer_notes: "Should answer from SRD race/basic movement text."
 
@@ -51,7 +51,7 @@ cases:
     question: "Does drinking a potion provoke an attack of opportunity?"
     question_type: exception_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Use a Potion"]
+    expected_section_or_entry: ["CombatI.rtf", "Table: Actions in Combat", "Drink a potion or apply an oil"]
     expected_behavior: direct_answer
     expected_answer_notes: "Should handle provoking behavior for potion use specifically."
 
@@ -59,7 +59,7 @@ cases:
     question: "Can you make attacks of opportunity while flat-footed?"
     question_type: exception_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Flat-Footed"]
+    expected_section_or_entry: ["AbilitiesandConditions.rtf", "Condition Summary", "Flat-Footed"]
     expected_behavior: direct_answer
     expected_answer_notes: "Should capture the flat-footed limitation."
 
@@ -67,7 +67,7 @@ cases:
     question: "Does firing a ranged weapon while threatened provoke an attack of opportunity?"
     question_type: exception_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Ranged Attacks"]
+    expected_section_or_entry: ["CombatI.rtf", "Table: Actions in Combat", "Attack (ranged)"]
     expected_behavior: direct_answer
     expected_answer_notes: "Should address the threatened-square exception behavior."
 
@@ -75,7 +75,7 @@ cases:
     question: "Can you run in heavy armor?"
     question_type: exception_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Movement", "Run", "Armor and Encumbrance"]
+    expected_section_or_entry: ["CombatI.rtf", "Run"]
     expected_behavior: direct_answer
     expected_answer_notes: "Should include the heavy-armor running restriction details."
 
@@ -83,9 +83,9 @@ cases:
     question: "Can a helpless target make attacks of opportunity?"
     question_type: exception_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Condition Summary", "Helpless", "Combat: Attacks of Opportunity"]
+    expected_section_or_entry: ["AbilitiesandConditions.rtf", "Condition Summary", "Helpless"]
     expected_behavior: supported_inference
-    expected_answer_notes: "Likely requires combining helpless-state constraints with AoO requirements."
+    expected_answer_notes: "Supported but weaker than flat-footed; requires cautious inference from helpless constraints."
 
   - eval_id: P1-NE-001
     question: "What does the Power Attack feat allow you to trade?"
@@ -96,12 +96,12 @@ cases:
     expected_answer_notes: "Should use the feat text directly."
 
   - eval_id: P1-NE-002
-    question: "What are the attack penalties for fighting with two weapons without the Two-Weapon Fighting feat?"
+    question: "Without the Two-Weapon Fighting feat and with a non-light off-hand weapon, what are the two-weapon attack penalties?"
     question_type: named_entry
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Combat: Two-Weapon Fighting"]
+    expected_section_or_entry: ["CombatII.rtf", "Table: Two-Weapon Fighting Penalties", "Off-hand weapon is not light"]
     expected_behavior: direct_answer
-    expected_answer_notes: "Should pull penalties from the two-weapon fighting rule."
+    expected_answer_notes: "Should return the non-light off-hand penalty row."
 
   - eval_id: P1-NE-003
     question: "How does the Dodge feat work?"
@@ -129,27 +129,27 @@ cases:
 
   - eval_id: P1-MC-001
     question: "Can you take a 5-foot step and still make a full attack?"
-    question_type: multi_chunk
+    question_type: direct_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Combat: Full Attack", "Combat: Movement", "5-Foot Step"]
-    expected_behavior: supported_inference
-    expected_answer_notes: "Needs combined reading of full-attack action and 5-foot-step rule."
+    expected_section_or_entry: ["CombatI.rtf", "Full Attack"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Full Attack text directly states the only movement allowed is a 5-foot step."
 
   - eval_id: P1-MC-002
     question: "If a character is invisible and attacks, what combat advantages apply to that first attack?"
     question_type: multi_chunk
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Condition Summary: Invisible", "Combat: Attack Roll Modifiers"]
+    expected_section_or_entry: ["AbilitiesandConditions.rtf", "Condition Summary", "Invisible", "SpellsH-L.rtf", "Invisibility"]
     expected_behavior: supported_inference
-    expected_answer_notes: "Requires combining condition effects with combat modifier rules."
+    expected_answer_notes: "Must include both first-attack combat advantage and attack-breaks-invisibility behavior."
 
   - eval_id: P1-MC-003
     question: "Can you cast defensively while threatened, and what check determines success?"
-    question_type: multi_chunk
+    question_type: direct_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Magic Overview: Concentration", "Casting Defensively"]
-    expected_behavior: supported_inference
-    expected_answer_notes: "Should connect AoO risk with defensive casting concentration checks."
+    expected_section_or_entry: ["CombatI.rtf", "Casting on the Defensive"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Single section directly gives no AoO and Concentration DC 15 + spell level."
 
   - eval_id: P1-MC-004
     question: "If you use Tumble to move through threatened squares, what does it prevent and what does it not prevent?"
@@ -161,11 +161,11 @@ cases:
 
   - eval_id: P1-MC-005
     question: "Can you charge through difficult terrain?"
-    question_type: multi_chunk
+    question_type: direct_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Combat: Charge", "Movement", "Terrain and Obstacles"]
-    expected_behavior: supported_inference
-    expected_answer_notes: "Should resolve charge constraints against terrain movement rules."
+    expected_section_or_entry: ["CombatII.rtf", "Difficult Terrain", "Charge"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Should answer directly from charge restrictions with difficult terrain."
 
   - eval_id: P1-TB-001
     question: "What Strength score carrying capacity applies to a medium load for Strength 10?"
@@ -193,11 +193,11 @@ cases:
 
   - eval_id: P1-TB-004
     question: "What cover bonus does improved cover grant?"
-    question_type: table_dependent
+    question_type: direct_lookup
     expected_source_ids: [srd_35]
-    expected_section_or_entry: ["Combat", "Cover", "Cover Table"]
+    expected_section_or_entry: ["CombatII.rtf", "Varying Degrees of Cover", "Improved Cover"]
     expected_behavior: direct_answer
-    expected_answer_notes: "Should return the improved cover benefit from the cover table."
+    expected_answer_notes: "Should answer from prose under Varying Degrees of Cover, not from a table."
 
   - eval_id: P1-TB-005
     question: "What size modifier applies to attack rolls for a Large creature?"

--- a/evals/phase1_gold.yaml
+++ b/evals/phase1_gold.yaml
@@ -1,6 +1,6 @@
 dataset_id: phase1_gold_v1
 dataset_version: 1
-created_on: 2026-04-11
+created_on: "2026-04-11"
 source_slice:
   source_ids:
     - srd_35

--- a/evals/phase1_gold.zh.yaml
+++ b/evals/phase1_gold.zh.yaml
@@ -1,0 +1,248 @@
+dataset_id: phase1_gold_zh_v1
+dataset_version: 1
+created_on: 2026-04-11
+source_slice:
+  source_ids:
+    - srd_35
+  edition: 3.5e
+  notes: "Phase 1 引导语料（srd_35）中文问题集。与 phase1_gold.yaml 共享同一批 eval_id。"
+cases:
+  - eval_id: P1-DL-001
+    question: "角色在什么情况下会因为移动而引发借机攻击（AoO）？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Attacks of Opportunity", "Movement"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应引用“离开威胁格会引发 AoO”的规则。"
+
+  - eval_id: P1-DL-002
+    question: "Total Defense 动作会对 AC 产生什么效果？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Actions in Combat", "Total Defense"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应直接给出 Total Defense 的 AC 效果。"
+
+  - eval_id: P1-DL-003
+    question: "人类在战斗中的默认移动速度是多少？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Races.rtf", "Races", "Humans"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应依据 SRD 种族/移动文本直接回答。"
+
+  - eval_id: P1-DL-004
+    question: "如果本轮进行了其他移动，还能进行 5-foot step 吗？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat: Movement", "5-Foot Step"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应明确“同轮不能有其他移动”的条件。"
+
+  - eval_id: P1-DL-005
+    question: "Dazzled 状态具体效果是什么？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Condition Summary", "Dazzled"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应使用该状态条目的定义直接回答。"
+
+  - eval_id: P1-EX-001
+    question: "喝药水是否会引发借机攻击？"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["CombatI.rtf", "Table: Actions in Combat", "Drink a potion or apply an oil"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应处理“喝药水”这一特定动作的引发规则。"
+
+  - eval_id: P1-EX-002
+    question: "Flat-Footed 状态下能进行借机攻击吗？"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["AbilitiesandConditions.rtf", "Condition Summary", "Flat-Footed"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应明确 flat-footed 的限制。"
+
+  - eval_id: P1-EX-003
+    question: "在敌人威胁范围内进行远程攻击会引发借机攻击吗？"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["CombatI.rtf", "Table: Actions in Combat", "Attack (ranged)"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应回答威胁格内远程攻击的例外处理。"
+
+  - eval_id: P1-EX-004
+    question: "穿重甲时可以 Run 吗？"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["CombatI.rtf", "Run"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应给出重甲对 Run 的限制。"
+
+  - eval_id: P1-EX-005
+    question: "Helpless 目标可以进行借机攻击吗？"
+    question_type: exception_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["AbilitiesandConditions.rtf", "Condition Summary", "Helpless"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "可支持但证据弱于 flat-footed；需要谨慎推断。"
+
+  - eval_id: P1-NE-001
+    question: "Power Attack 专长允许进行什么交换？"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Feats: Power Attack"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应直接使用专长条目文本。"
+
+  - eval_id: P1-NE-002
+    question: "在没有 Two-Weapon Fighting 专长且副手不是轻型武器时，双持攻击惩罚是多少？"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["CombatII.rtf", "Table: Two-Weapon Fighting Penalties", "Off-hand weapon is not light"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应返回表格中“副手非轻型武器”的惩罚行。"
+
+  - eval_id: P1-NE-003
+    question: "Dodge 专长是如何运作的？"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Feats: Dodge"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应包含指定目标相关要求。"
+
+  - eval_id: P1-NE-004
+    question: "Magic Missile 施放时是否需要攻击检定？"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Spells: Magic Missile"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应明确是否需要攻击检定。"
+
+  - eval_id: P1-NE-005
+    question: "Cleave 专长由什么条件触发？"
+    question_type: named_entry
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Feats: Cleave"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应给出条目中的触发条件。"
+
+  - eval_id: P1-MC-001
+    question: "进行 Full Attack 时还能走 5-foot step 吗？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["CombatI.rtf", "Full Attack"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "Full Attack 条文直接写明唯一允许移动是 5-foot step。"
+
+  - eval_id: P1-MC-002
+    question: "角色隐形时发动攻击，第一次攻击会获得哪些战斗优势？"
+    question_type: multi_chunk
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["AbilitiesandConditions.rtf", "Condition Summary", "Invisible", "SpellsH-L.rtf", "Invisibility"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "需要同时覆盖“首击优势”和“攻击后打破隐形”。"
+
+  - eval_id: P1-MC-003
+    question: "在被威胁时能否防御施法？成功检定是什么？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["CombatI.rtf", "Casting on the Defensive"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "单条规则即可给出不引发 AoO 与 DC 15 + spell level。"
+
+  - eval_id: P1-MC-004
+    question: "使用 Tumble 穿过威胁格时，能避免什么、不能避免什么？"
+    question_type: multi_chunk
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Skills: Tumble", "Combat: Attacks of Opportunity"]
+    expected_behavior: supported_inference
+    expected_answer_notes: "应结合技能限制与 AoO 基线规则。"
+
+  - eval_id: P1-MC-005
+    question: "可以穿过困难地形进行冲锋（Charge）吗？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["CombatII.rtf", "Difficult Terrain", "Charge"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应直接依据困难地形与冲锋限制回答。"
+
+  - eval_id: P1-TB-001
+    question: "力量 10 时，中负重区间是多少？"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Carrying Capacity Table", "Carrying and Exploration"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应引用力量 10 对应行。"
+
+  - eval_id: P1-TB-002
+    question: "属性值 18 对应的能力调整值是多少？"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Ability Scores", "Ability Modifiers Table"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应从能力调整值表读取。"
+
+  - eval_id: P1-TB-003
+    question: "Full Plate 的 armor check penalty 是多少？"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Equipment", "Armor and Shields Table", "Full Plate"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应引用护甲表中 full plate 对应行。"
+
+  - eval_id: P1-TB-004
+    question: "Improved cover 提供的掩护加值是多少？"
+    question_type: direct_lookup
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["CombatII.rtf", "Varying Degrees of Cover", "Improved Cover"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应从正文规则回答，而不是表格。"
+
+  - eval_id: P1-TB-005
+    question: "大型（Large）生物在攻击检定上的体型修正是多少？"
+    question_type: table_dependent
+    expected_source_ids: [srd_35]
+    expected_section_or_entry: ["Combat", "Creature Size Modifiers Table"]
+    expected_behavior: direct_answer
+    expected_answer_notes: "应从体型修正表读取攻击修正。"
+
+  - eval_id: P1-IE-001
+    question: "3.5e 里 warlock 的 Eldritch Blast 随等级如何成长？"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "Warlock 职业进阶不在当前 admitted 的 srd_35 引导切片内。"
+
+  - eval_id: P1-IE-002
+    question: "Artificer 在 5 级有多少 infusion slots？"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "Artificer 内容超出当前 admitted 语料边界。"
+
+  - eval_id: P1-IE-003
+    question: "我能花 inspiration 来让攻击获得 advantage 吗？"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "这是 5e 机制，超出当前 3.5e 语料范围。"
+
+  - eval_id: P1-IE-004
+    question: "5e 法师 1 级会多少个 cantrip？"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "版本越界问题，应该明确 abstain。"
+
+  - eval_id: P1-IE-005
+    question: "Hexblade's Curse 的效果是什么？"
+    question_type: insufficient_evidence
+    expected_source_ids: []
+    expected_section_or_entry: []
+    expected_behavior: abstain
+    expected_answer_notes: "Hexblade 特性不在当前 admitted source 边界内。"

--- a/evals/phase1_gold.zh.yaml
+++ b/evals/phase1_gold.zh.yaml
@@ -1,6 +1,6 @@
 dataset_id: phase1_gold_zh_v1
 dataset_version: 1
-created_on: 2026-04-11
+created_on: "2026-04-11"
 source_slice:
   source_ids:
     - srd_35


### PR DESCRIPTION
## Summary

Implements issue #6 by freezing a first-pass Phase 1 gold set against the admitted `srd_35` bootstrap slice.

## Changes

- Add `evals/phase1_gold.yaml` with 30 hand-curated cases.
- Add `evals/README.md` documenting case fields and regression usage.
- Mark roadmap checkpoint complete:
  - `Build a 20-30 question gold set for that slice`

## Coverage in `phase1_gold.yaml`

- direct lookup
- exception lookup
- named entry lookup
- multi-chunk support
- table-dependent lookup
- insufficient-evidence / out-of-scope abstain

## Contract alignment

Each case includes:

- `eval_id`
- `question`
- `question_type`
- `expected_source_ids`
- `expected_section_or_entry`
- `expected_behavior`
- `expected_answer_notes`

## Validation

Ran local parse/shape sanity check:

- YAML parse succeeds
- case count = 30
- question types include all six target categories
