### PR TITLE
Issue #17: PR evidence standard — fixture corpus, golden tests, preview script

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,8 +20,8 @@
 
 **Sources:** Bootstrap with `srd_35`, then expand deliberately to PHB, DMG, MM, and later official errata / FAQ as the contracts hold up.
 
-- [x] Implement ingestion pipeline (extraction + normalization)
-- [x] Add fixture corpus + golden outputs + preview evidence standard
+- [x] Implement ingestion pipeline (extraction + normalization) — `scripts/ingest_srd35/`
+- [x] Add fixture corpus + golden outputs + preview evidence standard — `tests/fixtures/`, `docs/standards/pr_evidence.md`
 - [ ] Implement chunker
 - [ ] Choose a baseline local vector index plus one embedding model and one answer model
 - [ ] Set up vector index and embedding pipeline

--- a/docs/zh/roadmap.md
+++ b/docs/zh/roadmap.md
@@ -20,8 +20,8 @@
 
 **Sources：** 先以 `srd_35` 为基线，随后在契约稳定后逐步扩展到 PHB / DMG / MM 与官方 errata / FAQ。
 
-- [x] 实现 ingestion pipeline（extraction + normalization）
-- [x] 加入 fixture corpus + golden outputs + preview evidence 标准
+- [x] 实现 ingestion pipeline（extraction + normalization）— `scripts/ingest_srd35/`
+- [x] 加入 fixture corpus + golden outputs + preview evidence 标准 — `tests/fixtures/`、`docs/standards/pr_evidence.md`
 - [ ] 实现 chunker
 - [ ] 选定 baseline 本地向量索引 + embedding 模型 + answer 模型
 - [ ] 搭建向量索引与 embedding 流水线


### PR DESCRIPTION
## Summary

Implements issue #17. Adds the committed evidence layer for pipeline PRs so reviewers can inspect actual behavior, not just code and unit test status.

## What changed

### 1. Committed fixture corpus (`tests/fixtures/srd_35/`)

Five synthetic RTF fixtures, each covering a distinct pipeline edge case:

| File | Edge case exercised |
|---|---|
| `CombatActions.rtf` | Multi-section document — heading splitting |
| `SkillDescriptions.rtf` | List and tab-separated DC table |
| `MonsterStats.rtf` | RTF `\cell` → ` | ` separator (table content) |
| `SpellComponents.rtf` | Near-heading false positives (`Evocation [Fire]`, `V, S, M`) |
| `BasicMechanics.rtf` | No headings — whole-file fallback behavior |

### 2. Committed golden expected outputs (`tests/fixtures/expected/`)

- `extracted/text/*.txt` — plain text output per fixture
- `canonical/*.json` — canonical document per fixture (`ingested_at` normalised to `__TIMESTAMP__`)

Golden diff in a PR = direct evidence of what the behavior change produces.

### 3. Golden comparison test (`tests/test_golden_ingestion.py`)

10 tests. Runs the pipeline over the fixture corpus and compares against golden files:
- exact extracted text match
- canonical JSON structural match (excluding timestamp)
- required provenance fields (`document_id`, `locator`, `source_checksum`, etc.)
- per-fixture behavioral assertions (section headings present, tabs preserved, cell separators, etc.)

Failure is intentionally verbose — the message tells you exactly what changed and how to regenerate.

### 4. Preview script (`scripts/preview_fixtures.py`)

Generates `tests/fixtures/PREVIEW.md` — a committed Markdown file showing RTF snippet → extracted text → canonical metadata for each fixture. Reviewable directly in GitHub without running anything.

Regenerate golden files + preview in one command:
```bash
python scripts/preview_fixtures.py --update-golden
```

### 5. PR evidence standard (`docs/pr_evidence.md`, `docs/zh/pr_evidence.md`)

Documents the minimum evidence per PR type:

| PR type | Required evidence |
|---|---|
| Ingestion behavior change | Updated golden diff + regenerated PREVIEW.md committed in same PR |
| Chunking behavior change | Updated golden chunk files + preview section |
| Retrieval behavior change | End-to-end example on fixture corpus in PR description |
| Schema change | Updated golden canonical files + `--require-schema-validation` output |
| RTF decoder change | Golden extracted text diff for affected fixtures |

## Verification

```
python -m unittest tests.test_golden_ingestion tests.test_ingest_srd_35 tests.test_fetch_srd_35 -v
```

**25 tests, all pass.**

```
python scripts/preview_fixtures.py
```

Regenerated `tests/fixtures/PREVIEW.md` — open it to inspect fixture behavior.

## Note for PR #16

When PR #16 (sectioning + hardening) merges, its pipeline changes will cause golden test failures by design. The PR #16 author should run:

```bash
python scripts/preview_fixtures.py --update-golden
```

and commit the updated golden diff as evidence of the sectioning behavior change.

Closes #17