### PR TITLE
docs: add Issue #33 lexical retrieval design and implementation plan

### DIFF
--- a/docs/plans/2026-04-12-lexical-retrieval-baseline-design.md
+++ b/docs/plans/2026-04-12-lexical-retrieval-baseline-design.md
@@ -1,0 +1,253 @@
+# Lexical Retrieval Baseline Design
+
+**Date:** 2026-04-12
+**Issue:** #33
+
+## 1. Goal
+
+Implement the Phase 1 lexical-first candidate generator over the chunk corpus using SQLite FTS5 with BM25 ranking. The output should be a small, inspectable candidate set that preserves chunk identity, rank, score, and simple match signals without taking on consolidation, hybrid retrieval, or answer-facing evidence packaging.
+
+## 2. Scope and Non-Goals
+
+### In Scope
+
+- Consume normalized query output from Issue #31.
+- Consume hard retrieval constraints from Issue #32.
+- Build and query a local SQLite FTS5 index over chunk content plus selected retrieval metadata.
+- Return top-k lexical candidates with stable ranking metadata and lightweight match signals.
+- Cover core rules queries such as `fighter hit die`, `attack of opportunity`, `turn undead`, and `what are bonus feats` in deterministic tests.
+
+### Non-Goals
+
+- Semantic or vector retrieval.
+- Candidate consolidation or near-duplicate collapse.
+- Adjacent chunk merge or section grouping.
+- Final evidence-pack selection or retrieval CLI formatting beyond what later issues need.
+- Pulling normalization or filtering logic into Issue #33 internals.
+
+## 3. Proposed Design
+
+### Minimal Data Flow
+
+```text
+User Question
+  ->
+NormalizedQuery          (#31)
+  +
+RetrievalConstraints     (#32)
+  ->
+LexicalRetriever
+  ->
+SQLite FTS5 Index
+  ->
+Raw Candidates (top-k)
+  ->
+Issue #33 output contract
+```
+
+The retrieval stage remains narrow by design. Query normalization and boundary filtering happen before scoring. Issue #33 only performs lexical search, ranking, and signal attachment.
+
+### Module Layout
+
+```text
+scripts/
+  retrieval/
+    __init__.py
+    contracts.py
+    lexical_index.py
+    lexical_retriever.py
+    match_signals.py
+
+tests/
+  test_lexical_retrieval.py
+```
+
+#### `contracts.py`
+
+Owns retrieval-facing dataclasses and stable output contracts. It should define typed objects for normalized query input, lexical candidate output, and any index-row helper shape needed internally.
+
+#### `lexical_index.py`
+
+Owns SQLite schema management and chunk ingestion into the lexical index. It should create:
+
+- `chunks_fts`: FTS5 virtual table for searchable text fields
+- `chunk_metadata`: ordinary table for metadata hydration
+
+It should support index rebuild from local chunk JSON files under `data/chunks/`.
+
+#### `lexical_retriever.py`
+
+Owns the core search path. It should:
+
+1. Accept a normalized query object, retrieval constraints, and top-k.
+2. Build an FTS5 `MATCH` query from normalized text and protected phrases.
+3. Query `chunks_fts`, rank with `bm25()`, and limit to top-k.
+4. Hydrate metadata from `chunk_metadata`.
+5. Attach lightweight match signals.
+6. Return stable lexical candidate objects.
+
+#### `match_signals.py`
+
+Owns simple, inspectable post-query signals only. Initial signals should include:
+
+- `exact_phrase_hits`
+- `protected_phrase_hits`
+- `section_path_hit`
+- `token_overlap_count`
+
+These are debug-oriented ranking clues, not secondary ranking stages.
+
+## 4. Data Model and Contracts
+
+### Normalized Query Contract
+
+Issue #33 should depend on a typed contract shaped like:
+
+```python
+@dataclass(frozen=True)
+class NormalizedQuery:
+    raw_query: str
+    normalized_text: str
+    tokens: list[str]
+    protected_phrases: list[str]
+    aliases_applied: list[dict[str, str]]
+```
+
+This may be adapted from the existing Issue #31 dict output by a thin constructor/helper, but the lexical retriever should depend on the typed contract rather than raw ad hoc dict access.
+
+### Retrieval Constraints Contract
+
+Issue #32 already exposes `RetrievalConstraints`. Issue #33 should use that contract directly rather than redefining filter rules locally. The lexical stage may translate accepted constraints into SQL predicates, but the source of truth remains the existing constraints object.
+
+### Candidate Output Contract
+
+```python
+@dataclass(frozen=True)
+class LexicalCandidate:
+    chunk_id: str
+    document_id: str
+    rank: int
+    raw_score: float
+    score_direction: str
+    chunk_type: str
+    source_ref: dict[str, object]
+    locator: dict[str, object]
+    match_signals: dict[str, object]
+```
+
+`score_direction` should be fixed to `"lower_is_better"` for SQLite FTS5 BM25 output so downstream consumers do not need to infer score semantics.
+
+## 5. Index Design
+
+### FTS Fields
+
+The lexical baseline only needs the chunk fields already produced by the chunker:
+
+- `chunk_id`
+- `document_id`
+- `content`
+- `section_path_text`
+- `chunk_type`
+- `source_id`
+- `edition`
+- `source_layer`
+
+`section_path_text` should be derived from `locator.section_path` and indexed because many rules queries are heading-dominant rather than body-dominant. This preserves the heading/body relationship emphasized in the retrieval design docs.
+
+### Table Separation
+
+The database should use a two-layer structure:
+
+- `chunks_fts` for FTS5 search
+- `chunk_metadata` for structured hydration
+
+This keeps full-text concerns separate from chunk metadata, avoids pushing full JSON blobs into the FTS table, and makes post-query hydration straightforward.
+
+## 6. Query and Ranking Behavior
+
+The minimum retrieval algorithm should be:
+
+1. Receive normalized query plus constraints.
+2. Extract `normalized_text` and `protected_phrases`.
+3. Build an FTS5 `MATCH` expression.
+4. Execute lexical retrieval with `bm25()` ordering.
+5. Take top-k rows.
+6. Compute match signals.
+7. Return raw lexical candidates.
+
+Issue #33 must stop there. It must not:
+
+- merge adjacent chunks
+- collapse near-duplicates
+- group by section
+- choose final evidence blocks
+
+Those behaviors belong to Issues #34 and #35.
+
+## 7. Testing Strategy
+
+### Recall Smoke Tests
+
+Use real local SRD chunk data and assert expected chunks appear in top-k for:
+
+- `fighter hit die`
+- `attack of opportunity`
+- `turn undead`
+- `what are bonus feats`
+
+The tests should verify presence in top-k and guard against obvious rank regressions.
+
+### Output Contract Tests
+
+Assert each returned candidate includes:
+
+- `chunk_id`
+- `rank`
+- `raw_score`
+- `score_direction`
+- `match_signals`
+- `source_ref`
+- `locator`
+
+### Match Signal Tests
+
+Assert:
+
+- exact phrase queries populate `exact_phrase_hits`
+- protected phrase matches populate `protected_phrase_hits`
+- heading matches set `section_path_hit`
+
+## 8. Key Decisions
+
+- Use SQLite FTS5 + BM25 now because it is local, inspectable, and sufficient for lexical-first MVP retrieval.
+- Keep lexical retrieval separate from normalization and hard filtering to preserve issue boundaries.
+- Index section-path text alongside chunk content because rules retrieval often hinges on section titles.
+- Return raw candidates only; postpone consolidation and evidence-pack shaping.
+
+## 9. Alternatives Considered
+
+### Pure Python BM25 over in-memory JSON
+
+Rejected for now because it would add custom ranking/index code where SQLite FTS5 already provides deterministic local search primitives with lower maintenance cost.
+
+### Single-table FTS-only storage
+
+Rejected because stuffing all metadata into the FTS table makes hydration and future debugging noisier. A separate metadata table keeps responsibilities cleaner.
+
+### Pulling filter logic into SQL only
+
+Rejected because Issue #32 already defines the admitted-source boundary. SQL should implement those constraints, not redefine them.
+
+## 10. Risks and Open Questions
+
+- SQLite builds without FTS5 support would block this approach; implementation should fail clearly if FTS5 is unavailable.
+- FTS5 query syntax around multiword protected phrases needs careful handling to avoid accidental query broadening.
+- Some recall gaps may still come from coarse chunking rather than lexical retrieval itself; tests should distinguish ranking misses from corpus-shape limitations.
+
+## 11. Next Steps
+
+1. Add TDD coverage for lexical candidate retrieval behavior.
+2. Implement typed retrieval contracts.
+3. Implement index build/hydration helpers over local chunk JSON.
+4. Implement lexical retrieval and match signals.
+5. Verify deterministic recall and output shape against real SRD chunks.

--- a/docs/plans/2026-04-12-lexical-retrieval-baseline.md
+++ b/docs/plans/2026-04-12-lexical-retrieval-baseline.md
@@ -1,0 +1,211 @@
+# Lexical Retrieval Baseline Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build Issue #33 as a lexical-first candidate generator using SQLite FTS5 and BM25 over Phase 1 chunk data, returning stable ranked candidates with lightweight match signals.
+
+**Architecture:** Keep retrieval layered: Issue #31 normalizes the query, Issue #32 defines hard boundaries, and Issue #33 performs lexical indexing, lexical search, and signal attachment only. Use a two-table SQLite layout with `chunks_fts` for search and `chunk_metadata` for hydration so the output contract stays stable and inspectable.
+
+**Tech Stack:** Python stdlib (`sqlite3`, `json`, `dataclasses`, `pathlib`), existing `scripts/retrieval/` package, pytest, local `data/chunks/srd_35`
+
+---
+
+### Task 1: Add failing contract tests for lexical retrieval outputs
+
+**Files:**
+- Create: `tests/test_lexical_retrieval.py`
+- Modify: `scripts/retrieval/__init__.py`
+
+**Step 1: Write the failing test**
+- Add a test that imports the planned retrieval contracts and retriever surface from `scripts.retrieval`.
+- Assert the public API can represent a lexical candidate with `chunk_id`, `rank`, `raw_score`, `score_direction`, `source_ref`, `locator`, and `match_signals`.
+- Add a test that expects `score_direction == "lower_is_better"`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_lexical_retrieval.py -v`
+Expected: FAIL because the lexical retrieval contracts and exports do not exist yet.
+
+**Step 3: Write minimal implementation**
+- Create `scripts/retrieval/contracts.py`.
+- Add dataclasses for `NormalizedQuery` adapter input and `LexicalCandidate`.
+- Export the new contracts from `scripts/retrieval/__init__.py`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_lexical_retrieval.py -v`
+Expected: PASS for the contract-shape tests.
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_lexical_retrieval.py scripts/retrieval/contracts.py scripts/retrieval/__init__.py
+git commit -m "feat(retrieval): add lexical retrieval contracts"
+```
+
+### Task 2: Add failing tests for SQLite lexical index build and metadata hydration
+
+**Files:**
+- Modify: `tests/test_lexical_retrieval.py`
+- Create: `scripts/retrieval/lexical_index.py`
+
+**Step 1: Write the failing test**
+- Add a test that builds a temporary SQLite database from a small fixture chunk set or a sampled local SRD chunk subset.
+- Assert the builder creates `chunks_fts` and `chunk_metadata`.
+- Assert `section_path_text` is derived from `locator.section_path`.
+- Assert metadata rows preserve `chunk_type`, `source_ref`, and `locator` for later hydration.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_lexical_retrieval.py -k "index or hydration" -v`
+Expected: FAIL because `lexical_index.py` and index build logic do not exist yet.
+
+**Step 3: Write minimal implementation**
+- Create the SQLite schema creation helpers.
+- Add chunk ingestion helpers that read chunk JSON, derive `section_path_text`, and insert rows into both tables.
+- Add clear failure when SQLite FTS5 support is unavailable.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_lexical_retrieval.py -k "index or hydration" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_lexical_retrieval.py scripts/retrieval/lexical_index.py
+git commit -m "feat(retrieval): add sqlite lexical index builder"
+```
+
+### Task 3: Add failing tests for match signal computation
+
+**Files:**
+- Modify: `tests/test_lexical_retrieval.py`
+- Create: `scripts/retrieval/match_signals.py`
+
+**Step 1: Write the failing test**
+- Add a test that a query for `attack of opportunity` records non-empty `exact_phrase_hits` and `protected_phrase_hits` when the phrase appears exactly.
+- Add a test that a matching heading in `section_path_text` sets `section_path_hit` to `True`.
+- Add a test that token overlap counts are deterministic for a simple candidate row.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_lexical_retrieval.py -k signals -v`
+Expected: FAIL because `match_signals.py` does not exist yet.
+
+**Step 3: Write minimal implementation**
+- Implement pure helper functions that compute `exact_phrase_hits`, `protected_phrase_hits`, `section_path_hit`, and `token_overlap_count`.
+- Keep this module read-only and post-query; do not add reranking here.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_lexical_retrieval.py -k signals -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_lexical_retrieval.py scripts/retrieval/match_signals.py
+git commit -m "feat(retrieval): add lexical match signals"
+```
+
+### Task 4: Add failing tests for lexical search over normalized queries and constraints
+
+**Files:**
+- Modify: `tests/test_lexical_retrieval.py`
+- Create: `scripts/retrieval/lexical_retriever.py`
+
+**Step 1: Write the failing test**
+- Add tests that call the lexical retriever with a normalized query object plus existing `RetrievalConstraints`.
+- Assert top-k results return ranked `LexicalCandidate` objects.
+- Assert rejected source boundaries are not returned when constraints exclude them.
+- Assert search results remain raw candidates and are not merged or deduplicated.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_lexical_retrieval.py -k "retriever or constraints" -v`
+Expected: FAIL because the lexical retriever surface does not exist yet.
+
+**Step 3: Write minimal implementation**
+- Implement `LexicalRetriever.search()`.
+- Translate normalized text and protected phrases into an FTS5 `MATCH` expression.
+- Join or hydrate metadata rows, compute `bm25()` scores, assign rank values, and attach match signals.
+- Reuse Issue #32 constraints instead of redefining filters locally.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_lexical_retrieval.py -k "retriever or constraints" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_lexical_retrieval.py scripts/retrieval/lexical_retriever.py
+git commit -m "feat(retrieval): add lexical candidate retrieval"
+```
+
+### Task 5: Add failing recall smoke tests against real SRD chunk data
+
+**Files:**
+- Modify: `tests/test_lexical_retrieval.py`
+- Review: `data/chunks/srd_35/`
+
+**Step 1: Write the failing test**
+- Add deterministic recall smoke tests for:
+  - `fighter hit die`
+  - `attack of opportunity`
+  - `turn undead`
+  - `what are bonus feats`
+- Assert an expected chunk or section identifier appears in top-k.
+- Add a mild rank guard where practical so obvious regressions are caught.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_lexical_retrieval.py -k "recall or smoke" -v`
+Expected: FAIL until the lexical retriever and index are wired to real chunk data correctly.
+
+**Step 3: Write minimal implementation**
+- Adjust FTS field coverage or match expression construction only as needed to satisfy the tests.
+- Keep the retriever lexical-first and domain-aware; do not add semantic fallback.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_lexical_retrieval.py -k "recall or smoke" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_lexical_retrieval.py scripts/retrieval/
+git commit -m "feat(retrieval): cover lexical recall smoke tests"
+```
+
+### Task 6: Run integrated verification and document the boundary
+
+**Files:**
+- Modify: `docs/plans/2026-04-12-lexical-retrieval-baseline-design.md` if implementation clarifies wording
+- Review: `scripts/retrieval/`
+- Review: `tests/test_lexical_retrieval.py`
+
+**Step 1: Write/update any missing failing test**
+- Add one final boundary test asserting the Issue #33 output contains raw ranked candidates only and does not expose consolidation fields from future issues.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_lexical_retrieval.py -k boundary -v`
+Expected: FAIL if the output contract has drifted beyond Issue #33 scope.
+
+**Step 3: Write minimal implementation**
+- Tighten exports, docs, or contract fields as needed.
+
+**Step 4: Run full verification**
+
+Run: `pytest tests/test_lexical_retrieval.py tests/test_query_normalization.py tests/test_retrieval_filters.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add docs/plans/2026-04-12-lexical-retrieval-baseline-design.md docs/plans/2026-04-12-lexical-retrieval-baseline.md tests/test_lexical_retrieval.py scripts/retrieval/
+git commit -m "feat(retrieval): implement lexical-first candidate baseline"
+```


### PR DESCRIPTION
## Summary
- add a design doc for the Issue #33 lexical-first retrieval baseline
- document the SQLite FTS5 + BM25 architecture, contracts, index layout, and scope boundary with #31/#32/#34/#35
- add a stepwise TDD implementation plan for the lexical retriever work

## Test Plan
- `PYTHONPATH=. pytest tests/test_query_normalization.py tests/test_retrieval_filters.py -v`

Refs #33