### PR TITLE
feat(retrieval): land first infrastructure slice for issue 33

### DIFF
--- a/scripts/retrieval/__init__.py
+++ b/scripts/retrieval/__init__.py
@@ -1,11 +1,21 @@
 from .contracts import LexicalCandidate, NormalizedQuery
+from .filters import (
+    apply_filters,
+    build_constraints,
+    FilterResult,
+    RetrievalConstraints,
+)
 from .query_normalization import normalize_query
 from .term_assets import get_default_term_assets, load_term_assets
 
 __all__ = [
+    "apply_filters",
+    "build_constraints",
+    "FilterResult",
     "get_default_term_assets",
     "LexicalCandidate",
     "load_term_assets",
     "normalize_query",
     "NormalizedQuery",
+    "RetrievalConstraints",
 ]

--- a/scripts/retrieval/__init__.py
+++ b/scripts/retrieval/__init__.py
@@ -1,18 +1,11 @@
-from .filters import (
-    apply_filters,
-    build_constraints,
-    FilterResult,
-    RetrievalConstraints,
-)
+from .contracts import LexicalCandidate, NormalizedQuery
 from .query_normalization import normalize_query
 from .term_assets import get_default_term_assets, load_term_assets
 
 __all__ = [
-    "apply_filters",
-    "build_constraints",
-    "FilterResult",
     "get_default_term_assets",
+    "LexicalCandidate",
     "load_term_assets",
     "normalize_query",
-    "RetrievalConstraints",
+    "NormalizedQuery",
 ]

--- a/scripts/retrieval/contracts.py
+++ b/scripts/retrieval/contracts.py
@@ -1,0 +1,42 @@
+"""Contracts for lexical retrieval."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class NormalizedQuery:
+    """Typed retrieval-facing query contract."""
+
+    raw_query: str
+    normalized_text: str
+    tokens: list[str]
+    protected_phrases: list[str]
+    aliases_applied: list[dict[str, str]]
+
+    @classmethod
+    def from_query_normalization(cls, payload: dict[str, Any]) -> "NormalizedQuery":
+        """Adapt the existing Issue #31 dict shape into a typed contract."""
+        return cls(
+            raw_query=payload["original_query"],
+            normalized_text=payload["normalized_text"],
+            tokens=list(payload["tokens"]),
+            protected_phrases=list(payload["protected_phrases"]),
+            aliases_applied=list(payload["alias_expansions"]),
+        )
+
+
+@dataclass(frozen=True)
+class LexicalCandidate:
+    """Stable candidate output for lexical retrieval."""
+
+    chunk_id: str
+    document_id: str
+    rank: int
+    raw_score: float
+    score_direction: str
+    chunk_type: str
+    source_ref: dict[str, Any]
+    locator: dict[str, Any]
+    match_signals: dict[str, Any]

--- a/scripts/retrieval/contracts.py
+++ b/scripts/retrieval/contracts.py
@@ -2,7 +2,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal, TypedDict
+
+
+class MatchSignals(TypedDict):
+    exact_phrase_hits: list[str]
+    protected_phrase_hits: list[str]
+    section_path_hit: bool
+    token_overlap_count: int
 
 
 @dataclass(frozen=True)
@@ -35,8 +42,8 @@ class LexicalCandidate:
     document_id: str
     rank: int
     raw_score: float
-    score_direction: str
+    score_direction: Literal["lower_is_better", "higher_is_better"]
     chunk_type: str
     source_ref: dict[str, Any]
     locator: dict[str, Any]
-    match_signals: dict[str, Any]
+    match_signals: MatchSignals

--- a/scripts/retrieval/filters.py
+++ b/scripts/retrieval/filters.py
@@ -132,6 +132,7 @@ def build_constraints(
 
 @lru_cache(maxsize=1)
 def _default_constraints() -> RetrievalConstraints:
+    """Cache registry-derived defaults; tests can clear via `_default_constraints.cache_clear()`."""
     return build_constraints()
 
 

--- a/scripts/retrieval/filters.py
+++ b/scripts/retrieval/filters.py
@@ -25,11 +25,7 @@ class RetrievalConstraints:
     excluded_source_ids: frozenset[str]
 
     def accepts(self, chunk: dict[str, Any]) -> bool:
-        """Return True if chunk passes all hard filters.
-
-        Reads filter fields from ``source_ref`` (the real chunk shape)
-        and falls back to top-level keys for flat metadata dicts.
-        """
+        """Return True if chunk passes all hard filters."""
         ref = _extract_source_ref(chunk)
         edition = ref.get("edition", "")
         source_type = ref.get("source_type", "")
@@ -80,17 +76,15 @@ class FilterResult:
 
 
 def _extract_source_ref(chunk: dict[str, Any]) -> dict[str, Any]:
-    """Return the source_ref sub-dict, falling back to the chunk itself."""
     return chunk.get("source_ref", chunk)
 
 
 def _load_source_registry(path: Path | None = None) -> list[dict]:
-    """Load and validate source entries from source_registry.yaml."""
     import yaml
 
     registry_path = path or SOURCE_REGISTRY
-    with registry_path.open("r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+    with registry_path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
 
     if not isinstance(data, dict):
         raise ValueError(
@@ -111,12 +105,7 @@ def build_constraints(
     registry_path: Path | None = None,
     excluded_source_ids: frozenset[str] | None = None,
 ) -> RetrievalConstraints:
-    """Derive constraints from the admitted sources in source_registry.yaml.
-
-    Only sources whose status is not ``planned_later`` contribute to
-    the allowlists.  This keeps the filter boundary in sync with what
-    the project has actually admitted — no second config to drift.
-    """
+    """Derive hard-filter constraints from admitted sources."""
     sources = _load_source_registry(registry_path)
 
     editions: set[str] = set()
@@ -128,10 +117,10 @@ def build_constraints(
             continue
         if edition := src.get("edition"):
             editions.add(edition)
-        if stype := src.get("source_type"):
-            source_types.add(stype)
-        if auth := src.get("authority_level"):
-            authority_levels.add(auth)
+        if source_type := src.get("source_type"):
+            source_types.add(source_type)
+        if authority_level := src.get("authority_level"):
+            authority_levels.add(authority_level)
 
     return RetrievalConstraints(
         editions=frozenset(editions),
@@ -143,13 +132,6 @@ def build_constraints(
 
 @lru_cache(maxsize=1)
 def _default_constraints() -> RetrievalConstraints:
-    """Cached default constraints derived from source_registry.yaml.
-
-    Avoids re-parsing the registry on every per-query ``apply_filters``
-    call.  The registry is small and static at runtime, so a single
-    cached instance is safe.  Tests that mutate the registry can call
-    ``_default_constraints.cache_clear()``.
-    """
     return build_constraints()
 
 
@@ -162,12 +144,12 @@ def apply_filters(
         constraints = _default_constraints()
 
     result = FilterResult(constraints=constraints)
-    for i, candidate in enumerate(candidates):
+    for index, candidate in enumerate(candidates):
         reason = constraints.rejection_reason(candidate)
         if reason is None:
             result.accepted.append(candidate)
         else:
             result.rejected.append(candidate)
-            result.rejection_reasons[i] = reason
+            result.rejection_reasons[index] = reason
 
     return result

--- a/scripts/retrieval/lexical_index.py
+++ b/scripts/retrieval/lexical_index.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 
 def build_chunk_index(db_path: Path, chunk_paths: Iterable[Path]) -> None:
@@ -16,6 +16,47 @@ def build_chunk_index(db_path: Path, chunk_paths: Iterable[Path]) -> None:
         _create_schema(connection)
         _replace_rows(connection, chunk_paths)
         connection.commit()
+
+
+def search_chunk_index(db_path: Path, query_text: str, *, top_k: int = 5) -> list[dict[str, Any]]:
+    """Run an FTS query and return hydrated top-k rows."""
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute(
+            """
+            SELECT
+                chunk_metadata.chunk_id,
+                chunk_metadata.document_id,
+                chunk_metadata.section_path_text,
+                chunk_metadata.chunk_type,
+                chunk_metadata.source_ref_json,
+                chunk_metadata.locator_json,
+                chunk_metadata.content,
+                bm25(chunks_fts) AS raw_score
+            FROM chunks_fts
+            JOIN chunk_metadata ON chunk_metadata.chunk_id = chunks_fts.chunk_id
+            WHERE chunks_fts MATCH ?
+            ORDER BY raw_score ASC
+            LIMIT ?
+            """,
+            (query_text, top_k),
+        ).fetchall()
+
+    hydrated: list[dict[str, Any]] = []
+    for rank, row in enumerate(rows, start=1):
+        hydrated.append(
+            {
+                "chunk_id": row[0],
+                "document_id": row[1],
+                "section_path_text": row[2],
+                "chunk_type": row[3],
+                "source_ref": json.loads(row[4]),
+                "locator": json.loads(row[5]),
+                "content": row[6],
+                "raw_score": float(row[7]),
+                "rank": rank,
+            }
+        )
+    return hydrated
 
 
 def _create_schema(connection: sqlite3.Connection) -> None:

--- a/scripts/retrieval/lexical_index.py
+++ b/scripts/retrieval/lexical_index.py
@@ -5,6 +5,7 @@ import json
 import sqlite3
 from pathlib import Path
 from typing import Iterable
+from uuid import uuid4
 
 from .contracts import LexicalCandidate
 
@@ -13,11 +14,22 @@ def build_chunk_index(db_path: Path, chunk_paths: Iterable[Path]) -> None:
     """Create a lexical index database from chunk JSON files."""
     db_path = Path(db_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_db_path = db_path.with_name(f"{db_path.name}.{uuid4().hex}.tmp")
+    connection: sqlite3.Connection | None = None
 
-    with sqlite3.connect(db_path) as connection:
+    try:
+        connection = sqlite3.connect(temp_db_path)
         _create_schema(connection)
         _replace_rows(connection, chunk_paths)
         connection.commit()
+        connection.close()
+        connection = None
+        temp_db_path.replace(db_path)
+    except Exception:
+        if connection is not None:
+            connection.close()
+        temp_db_path.unlink(missing_ok=True)
+        raise
 
 
 def search_chunk_index(db_path: Path, query_text: str, *, top_k: int = 5) -> list[LexicalCandidate]:

--- a/scripts/retrieval/lexical_index.py
+++ b/scripts/retrieval/lexical_index.py
@@ -1,0 +1,120 @@
+"""SQLite index helpers for lexical retrieval."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+
+def build_chunk_index(db_path: Path, chunk_paths: Iterable[Path]) -> None:
+    """Create a lexical index database from chunk JSON files."""
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(db_path) as connection:
+        _create_schema(connection)
+        _replace_rows(connection, chunk_paths)
+        connection.commit()
+
+
+def _create_schema(connection: sqlite3.Connection) -> None:
+    connection.execute("DROP TABLE IF EXISTS chunk_metadata")
+    connection.execute("DROP TABLE IF EXISTS chunks_fts")
+    try:
+        connection.execute(
+            """
+            CREATE VIRTUAL TABLE chunks_fts USING fts5(
+                chunk_id UNINDEXED,
+                document_id UNINDEXED,
+                content,
+                section_path_text,
+                chunk_type,
+                source_id,
+                edition,
+                source_layer
+            )
+            """
+        )
+    except sqlite3.OperationalError as exc:
+        raise RuntimeError("SQLite FTS5 support is required for lexical retrieval.") from exc
+
+    connection.execute(
+        """
+        CREATE TABLE chunk_metadata (
+            chunk_id TEXT PRIMARY KEY,
+            document_id TEXT NOT NULL,
+            section_path_text TEXT NOT NULL,
+            chunk_type TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            edition TEXT NOT NULL,
+            source_layer TEXT NOT NULL,
+            source_ref_json TEXT NOT NULL,
+            locator_json TEXT NOT NULL,
+            content TEXT NOT NULL
+        )
+        """
+    )
+
+
+def _replace_rows(connection: sqlite3.Connection, chunk_paths: Iterable[Path]) -> None:
+    for chunk_path in chunk_paths:
+        chunk = json.loads(Path(chunk_path).read_text(encoding="utf-8"))
+        locator = chunk["locator"]
+        source_ref = chunk["source_ref"]
+        section_path = locator.get("section_path", [])
+        section_path_text = " ".join(section_path)
+        source_layer = source_ref.get("source_type", "")
+
+        connection.execute(
+            """
+            INSERT INTO chunk_metadata (
+                chunk_id,
+                document_id,
+                section_path_text,
+                chunk_type,
+                source_id,
+                edition,
+                source_layer,
+                source_ref_json,
+                locator_json,
+                content
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chunk["chunk_id"],
+                chunk["document_id"],
+                section_path_text,
+                chunk["chunk_type"],
+                source_ref["source_id"],
+                source_ref["edition"],
+                source_layer,
+                json.dumps(source_ref, ensure_ascii=True, sort_keys=True),
+                json.dumps(locator, ensure_ascii=True, sort_keys=True),
+                chunk["content"],
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO chunks_fts (
+                chunk_id,
+                document_id,
+                content,
+                section_path_text,
+                chunk_type,
+                source_id,
+                edition,
+                source_layer
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                chunk["chunk_id"],
+                chunk["document_id"],
+                chunk["content"],
+                section_path_text,
+                chunk["chunk_type"],
+                source_ref["source_id"],
+                source_ref["edition"],
+                source_layer,
+            ),
+        )

--- a/scripts/retrieval/lexical_index.py
+++ b/scripts/retrieval/lexical_index.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Iterable
+
+from .contracts import LexicalCandidate
 
 
 def build_chunk_index(db_path: Path, chunk_paths: Iterable[Path]) -> None:
@@ -18,8 +20,14 @@ def build_chunk_index(db_path: Path, chunk_paths: Iterable[Path]) -> None:
         connection.commit()
 
 
-def search_chunk_index(db_path: Path, query_text: str, *, top_k: int = 5) -> list[dict[str, Any]]:
-    """Run an FTS query and return hydrated top-k rows."""
+def search_chunk_index(db_path: Path, query_text: str, *, top_k: int = 5) -> list[LexicalCandidate]:
+    """Run an FTS query and return hydrated top-k rows.
+
+    ``query_text`` must already be a valid SQLite FTS5 MATCH expression.
+    This helper does not sanitize raw user input.
+    """
+    if top_k <= 0:
+        return []
     with sqlite3.connect(db_path) as connection:
         rows = connection.execute(
             """
@@ -41,20 +49,25 @@ def search_chunk_index(db_path: Path, query_text: str, *, top_k: int = 5) -> lis
             (query_text, top_k),
         ).fetchall()
 
-    hydrated: list[dict[str, Any]] = []
+    hydrated: list[LexicalCandidate] = []
     for rank, row in enumerate(rows, start=1):
         hydrated.append(
-            {
-                "chunk_id": row[0],
-                "document_id": row[1],
-                "section_path_text": row[2],
-                "chunk_type": row[3],
-                "source_ref": json.loads(row[4]),
-                "locator": json.loads(row[5]),
-                "content": row[6],
-                "raw_score": float(row[7]),
-                "rank": rank,
-            }
+            LexicalCandidate(
+                chunk_id=row[0],
+                document_id=row[1],
+                rank=rank,
+                raw_score=float(row[7]),
+                score_direction="lower_is_better",
+                chunk_type=row[3],
+                source_ref=json.loads(row[4]),
+                locator=json.loads(row[5]),
+                match_signals={
+                    "exact_phrase_hits": [],
+                    "protected_phrase_hits": [],
+                    "section_path_hit": False,
+                    "token_overlap_count": 0,
+                },
+            )
         )
     return hydrated
 
@@ -103,9 +116,9 @@ def _replace_rows(connection: sqlite3.Connection, chunk_paths: Iterable[Path]) -
         chunk = json.loads(Path(chunk_path).read_text(encoding="utf-8"))
         locator = chunk["locator"]
         source_ref = chunk["source_ref"]
-        section_path = locator.get("section_path", [])
+        section_path = locator["section_path"]
         section_path_text = " ".join(section_path)
-        source_layer = source_ref.get("source_type", "")
+        source_layer = source_ref["source_type"]
 
         connection.execute(
             """

--- a/scripts/retrieval/match_signals.py
+++ b/scripts/retrieval/match_signals.py
@@ -23,7 +23,9 @@ def build_match_signals(
         exact_phrase_hits.append(query.normalized_text)
 
     protected_phrase_hits = [
-        phrase for phrase in query.protected_phrases if phrase.casefold() in haystack
+        phrase
+        for phrase in query.protected_phrases
+        if _contains_phrase_on_token_boundaries(haystack, phrase.casefold())
     ]
 
     query_terms = {

--- a/scripts/retrieval/match_signals.py
+++ b/scripts/retrieval/match_signals.py
@@ -1,0 +1,46 @@
+"""Match-signal helpers for lexical retrieval candidates."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .contracts import NormalizedQuery
+
+
+def build_match_signals(
+    query: NormalizedQuery,
+    chunk: dict[str, Any],
+    section_path_text: str,
+) -> dict[str, Any]:
+    """Compute lightweight lexical match signals for a candidate chunk."""
+    content = chunk.get("content", "")
+    haystack = f"{section_path_text} {content}".casefold()
+    normalized_text = query.normalized_text.casefold()
+    lowered_section_path = section_path_text.casefold()
+
+    exact_phrase_hits: list[str] = []
+    if normalized_text and normalized_text in haystack:
+        exact_phrase_hits.append(query.normalized_text)
+
+    protected_phrase_hits = [
+        phrase for phrase in query.protected_phrases if phrase.casefold() in haystack
+    ]
+
+    query_terms = {
+        token.casefold()
+        for token in query.tokens
+        if token and " " not in token
+    }
+    content_terms = set(re.findall(r"\w+", content.casefold()))
+    token_overlap_count = len(query_terms & content_terms)
+
+    return {
+        "exact_phrase_hits": exact_phrase_hits,
+        "protected_phrase_hits": protected_phrase_hits,
+        "section_path_hit": any(
+            phrase.casefold() in lowered_section_path
+            for phrase in [query.normalized_text, *query.protected_phrases]
+            if phrase
+        ),
+        "token_overlap_count": token_overlap_count,
+    }

--- a/scripts/retrieval/match_signals.py
+++ b/scripts/retrieval/match_signals.py
@@ -19,7 +19,7 @@ def build_match_signals(
     lowered_section_path = section_path_text.casefold()
 
     exact_phrase_hits: list[str] = []
-    if normalized_text and normalized_text in haystack:
+    if _contains_phrase_on_token_boundaries(haystack, normalized_text):
         exact_phrase_hits.append(query.normalized_text)
 
     protected_phrase_hits = [
@@ -38,9 +38,15 @@ def build_match_signals(
         "exact_phrase_hits": exact_phrase_hits,
         "protected_phrase_hits": protected_phrase_hits,
         "section_path_hit": any(
-            phrase.casefold() in lowered_section_path
+            _contains_phrase_on_token_boundaries(lowered_section_path, phrase.casefold())
             for phrase in [query.normalized_text, *query.protected_phrases]
             if phrase
         ),
         "token_overlap_count": token_overlap_count,
     }
+
+
+def _contains_phrase_on_token_boundaries(haystack: str, phrase: str) -> bool:
+    if not phrase:
+        return False
+    return re.search(rf"(?<!\w){re.escape(phrase)}(?!\w)", haystack) is not None

--- a/scripts/retrieval/match_signals.py
+++ b/scripts/retrieval/match_signals.py
@@ -27,12 +27,12 @@ def build_match_signals(
     ]
 
     query_terms = {
-        token.casefold()
+        term
         for token in query.tokens
-        if token and " " not in token
+        for term in re.findall(r"\w+", token.casefold())
     }
-    content_terms = set(re.findall(r"\w+", content.casefold()))
-    token_overlap_count = len(query_terms & content_terms)
+    haystack_terms = set(re.findall(r"\w+", haystack))
+    token_overlap_count = len(query_terms & haystack_terms)
 
     return {
         "exact_phrase_hits": exact_phrase_hits,

--- a/tests/test_lexical_retrieval.py
+++ b/tests/test_lexical_retrieval.py
@@ -423,3 +423,21 @@ def test_build_match_signals_does_not_mark_exact_phrase_inside_larger_word(sampl
     signals = build_match_signals(query, chunk, "Combat Retreat")
 
     assert signals["exact_phrase_hits"] == []
+
+
+def test_build_match_signals_does_not_mark_protected_phrase_inside_larger_word(sample_chunk) -> None:
+    query = NormalizedQuery(
+        raw_query="turn",
+        normalized_text="turn",
+        tokens=["turn"],
+        protected_phrases=["turn"],
+        aliases_applied=[],
+    )
+    chunk = {
+        **sample_chunk,
+        "content": "Creatures can return to the fight after resting.",
+    }
+
+    signals = build_match_signals(query, chunk, "Combat Retreat")
+
+    assert signals["protected_phrase_hits"] == []

--- a/tests/test_lexical_retrieval.py
+++ b/tests/test_lexical_retrieval.py
@@ -7,7 +7,15 @@ from pathlib import Path
 
 import pytest
 
-from scripts.retrieval import LexicalCandidate, NormalizedQuery, normalize_query
+from scripts.retrieval import (
+    apply_filters,
+    build_constraints,
+    FilterResult,
+    LexicalCandidate,
+    NormalizedQuery,
+    RetrievalConstraints,
+    normalize_query,
+)
 from scripts.retrieval.lexical_index import _create_schema, build_chunk_index, search_chunk_index
 from scripts.retrieval.match_signals import build_match_signals
 
@@ -114,6 +122,14 @@ def test_contract_exports_lexical_types() -> None:
     assert candidate.score_direction == "lower_is_better"
 
 
+def test_package_exports_preserve_filter_symbols() -> None:
+    constraints = build_constraints()
+    result = apply_filters([])
+
+    assert isinstance(constraints, RetrievalConstraints)
+    assert isinstance(result, FilterResult)
+
+
 def test_from_query_normalization_adapts_real_payload() -> None:
     payload = normalize_query("fighter hp")
 
@@ -181,9 +197,63 @@ def test_search_chunk_index_returns_ranked_candidates_from_fts(tmp_path, sample_
     build_chunk_index(db_path, [aoo_path, turn_path])
     results = search_chunk_index(db_path, "\"attack of opportunity\"", top_k=2)
 
-    assert [result["rank"] for result in results] == [1]
-    assert results[0]["chunk_id"] == sample_chunk["chunk_id"]
-    assert results[0]["raw_score"] <= 0
+    assert [result.rank for result in results] == [1]
+    assert results[0].chunk_id == sample_chunk["chunk_id"]
+    assert results[0].raw_score <= 0
+
+
+def test_search_chunk_index_returns_empty_for_no_match(tmp_path, sample_chunk) -> None:
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "attack_of_opportunity.json", sample_chunk)
+
+    build_chunk_index(db_path, [chunk_path])
+    results = search_chunk_index(db_path, "\"turn undead\"", top_k=3)
+
+    assert results == []
+
+
+def test_search_chunk_index_returns_empty_for_zero_top_k(tmp_path, sample_chunk) -> None:
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "attack_of_opportunity.json", sample_chunk)
+
+    build_chunk_index(db_path, [chunk_path])
+
+    assert search_chunk_index(db_path, "\"attack of opportunity\"", top_k=0) == []
+
+
+def test_search_chunk_index_orders_multiple_candidates_by_bm25(tmp_path, sample_chunk) -> None:
+    db_path = tmp_path / "retrieval.db"
+    stronger = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::combat::010_turn_undead_dense",
+        "document_id": "srd_35::combat::010_turn_undead_dense",
+        "locator": {
+            "section_path": ["Combat", "Turning Checks"],
+            "source_location": "Combat.rtf#010_turn_undead_dense",
+        },
+        "content": "Turn undead lets a cleric turn undead. A turn undead attempt affects undead.",
+    }
+    weaker = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::combat::011_turn_undead_sparse",
+        "document_id": "srd_35::combat::011_turn_undead_sparse",
+        "locator": {
+            "section_path": ["Combat", "Turning"],
+            "source_location": "Combat.rtf#011_turn_undead_sparse",
+        },
+        "content": "A cleric can turn undead with divine power.",
+    }
+    stronger_path = _write_chunk(tmp_path / "stronger.json", stronger)
+    weaker_path = _write_chunk(tmp_path / "weaker.json", weaker)
+
+    build_chunk_index(db_path, [stronger_path, weaker_path])
+    results = search_chunk_index(db_path, "\"turn undead\"", top_k=2)
+
+    assert [result.chunk_id for result in results] == [
+        stronger["chunk_id"],
+        weaker["chunk_id"],
+    ]
+    assert results[0].raw_score <= results[1].raw_score
 
 
 def test_search_chunk_index_supports_real_corpus_turn_undead_recall(tmp_path) -> None:
@@ -194,7 +264,7 @@ def test_search_chunk_index_supports_real_corpus_turn_undead_recall(tmp_path) ->
     results = search_chunk_index(db_path, "\"turn undead\"", top_k=3)
 
     assert results
-    assert results[0]["chunk_id"] == "chunk::srd_35::combatii::029_turning_checks"
+    assert results[0].chunk_id == "chunk::srd_35::combatii::029_turning_checks"
 
 
 def test_search_chunk_index_supports_real_corpus_bonus_feats_recall(tmp_path) -> None:
@@ -205,7 +275,7 @@ def test_search_chunk_index_supports_real_corpus_bonus_feats_recall(tmp_path) ->
     results = search_chunk_index(db_path, "\"fighter bonus feats\"", top_k=3)
 
     assert results
-    assert results[0]["chunk_id"] == "chunk::srd_35::feats::004_fighter_bonus_feats"
+    assert results[0].chunk_id == "chunk::srd_35::feats::004_fighter_bonus_feats"
 
 
 def test_build_chunk_index_rebuilds_cleanly(tmp_path, sample_chunk) -> None:
@@ -230,7 +300,7 @@ def test_build_chunk_index_rebuilds_cleanly(tmp_path, sample_chunk) -> None:
     fresh = search_chunk_index(db_path, "\"turn undead\"", top_k=3)
 
     assert stale == []
-    assert fresh[0]["chunk_id"] == second_chunk["chunk_id"]
+    assert fresh[0].chunk_id == second_chunk["chunk_id"]
 
 
 def test_build_chunk_index_raises_on_malformed_chunk_shape(tmp_path) -> None:

--- a/tests/test_lexical_retrieval.py
+++ b/tests/test_lexical_retrieval.py
@@ -312,6 +312,21 @@ def test_build_chunk_index_raises_on_malformed_chunk_shape(tmp_path) -> None:
         build_chunk_index(db_path, [broken_path])
 
 
+def test_build_chunk_index_preserves_existing_index_when_rebuild_fails(tmp_path, sample_chunk) -> None:
+    db_path = tmp_path / "retrieval.db"
+    good_path = _write_chunk(tmp_path / "good.json", sample_chunk)
+    broken_path = _write_chunk(tmp_path / "broken.json", {"chunk_id": "broken"})
+
+    build_chunk_index(db_path, [good_path])
+
+    with pytest.raises(KeyError):
+        build_chunk_index(db_path, [broken_path])
+
+    results = search_chunk_index(db_path, "\"attack of opportunity\"", top_k=3)
+
+    assert [result.chunk_id for result in results] == [sample_chunk["chunk_id"]]
+
+
 def test_create_schema_raises_when_fts5_is_unavailable(monkeypatch) -> None:
     class FakeConnection:
         def execute(self, sql: str):
@@ -390,3 +405,21 @@ def test_build_match_signals_counts_token_overlap_across_section_and_content(sam
     assert signals["protected_phrase_hits"] == []
     assert signals["section_path_hit"] is False
     assert signals["token_overlap_count"] == 3
+
+
+def test_build_match_signals_does_not_mark_exact_phrase_inside_larger_word(sample_chunk) -> None:
+    query = NormalizedQuery(
+        raw_query="turn",
+        normalized_text="turn",
+        tokens=["turn"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    chunk = {
+        **sample_chunk,
+        "content": "Creatures can return to the fight after resting.",
+    }
+
+    signals = build_match_signals(query, chunk, "Combat Retreat")
+
+    assert signals["exact_phrase_hits"] == []

--- a/tests/test_lexical_retrieval.py
+++ b/tests/test_lexical_retrieval.py
@@ -1,0 +1,128 @@
+"""Tests for Issue #33 lexical retrieval baseline."""
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from scripts.retrieval import LexicalCandidate, NormalizedQuery
+from scripts.retrieval.lexical_index import build_chunk_index
+from scripts.retrieval.match_signals import build_match_signals
+
+
+def test_contract_exports_lexical_types() -> None:
+    query = NormalizedQuery(
+        raw_query="fighter hp",
+        normalized_text="fighter hit points",
+        tokens=["fighter", "hit points"],
+        protected_phrases=["hit points"],
+        aliases_applied=[{"source": "hp", "target": "hit points"}],
+    )
+    candidate = LexicalCandidate(
+        chunk_id="chunk::srd_35::fighter::001_fighter",
+        document_id="srd_35::fighter::001_fighter",
+        rank=1,
+        raw_score=-3.25,
+        score_direction="lower_is_better",
+        chunk_type="rule_section",
+        source_ref={
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        locator={
+            "section_path": ["Classes", "Fighter"],
+            "source_location": "Classes.rtf#fighter",
+        },
+        match_signals={"token_overlap_count": 2},
+    )
+
+    assert query.normalized_text == "fighter hit points"
+    assert candidate.chunk_id.endswith("fighter")
+    assert candidate.score_direction == "lower_is_better"
+
+
+@pytest.fixture
+def sample_chunk() -> dict:
+    return {
+        "chunk_id": "chunk::srd_35::combat::001_attack_of_opportunity",
+        "document_id": "srd_35::combat::001_attack_of_opportunity",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "source_location": "Combat.rtf#001_attack_of_opportunity",
+        },
+        "chunk_type": "rule_section",
+        "content": "An attack of opportunity is a single melee attack.",
+    }
+
+
+def test_build_chunk_index_creates_fts_and_metadata_tables(tmp_path, sample_chunk) -> None:
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = tmp_path / "attack_of_opportunity.json"
+    chunk_path.write_text(json.dumps(sample_chunk), encoding="utf-8")
+
+    build_chunk_index(db_path, [chunk_path])
+
+    with sqlite3.connect(db_path) as connection:
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'view')"
+            )
+        }
+        metadata_row = connection.execute(
+            "SELECT section_path_text, chunk_type, source_ref_json, locator_json "
+            "FROM chunk_metadata WHERE chunk_id = ?",
+            (sample_chunk["chunk_id"],),
+        ).fetchone()
+
+    assert "chunk_metadata" in tables
+    assert "chunks_fts" in tables
+    assert metadata_row is not None
+    assert metadata_row[0] == "Combat Attack of Opportunity"
+    assert metadata_row[1] == "rule_section"
+    assert json.loads(metadata_row[2])["source_id"] == "srd_35"
+    assert json.loads(metadata_row[3])["section_path"] == ["Combat", "Attack of Opportunity"]
+
+
+def test_build_match_signals_tracks_exact_and_protected_phrases(sample_chunk) -> None:
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+
+    signals = build_match_signals(query, sample_chunk, "Combat Attack of Opportunity")
+
+    assert signals["exact_phrase_hits"] == ["attack of opportunity"]
+    assert signals["protected_phrase_hits"] == ["attack of opportunity"]
+    assert signals["section_path_hit"] is True
+
+
+def test_build_match_signals_counts_token_overlap(sample_chunk) -> None:
+    query = NormalizedQuery(
+        raw_query="single melee attack",
+        normalized_text="single melee attack",
+        tokens=["single", "melee", "attack"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+
+    signals = build_match_signals(query, sample_chunk, "Combat Attack of Opportunity")
+
+    assert signals["exact_phrase_hits"] == ["single melee attack"]
+    assert signals["protected_phrase_hits"] == []
+    assert signals["section_path_hit"] is False
+    assert signals["token_overlap_count"] == 3

--- a/tests/test_lexical_retrieval.py
+++ b/tests/test_lexical_retrieval.py
@@ -3,12 +3,81 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from pathlib import Path
 
 import pytest
 
-from scripts.retrieval import LexicalCandidate, NormalizedQuery
-from scripts.retrieval.lexical_index import build_chunk_index
+from scripts.retrieval import LexicalCandidate, NormalizedQuery, normalize_query
+from scripts.retrieval.lexical_index import _create_schema, build_chunk_index, search_chunk_index
 from scripts.retrieval.match_signals import build_match_signals
+
+
+@pytest.fixture
+def sample_chunk() -> dict:
+    return {
+        "chunk_id": "chunk::srd_35::combat::001_attack_of_opportunity",
+        "document_id": "srd_35::combat::001_attack_of_opportunity",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "source_location": "Combat.rtf#001_attack_of_opportunity",
+        },
+        "chunk_type": "rule_section",
+        "content": "An attack of opportunity is a single melee attack.",
+    }
+
+
+@pytest.fixture
+def title_only_chunk() -> dict:
+    return {
+        "chunk_id": "chunk::srd_35::combat::002_aoo_title_only",
+        "document_id": "srd_35::combat::002_aoo_title_only",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "source_location": "Combat.rtf#002_aoo_title_only",
+        },
+        "chunk_type": "subsection",
+        "content": "This section explains when creatures threaten squares.",
+    }
+
+
+@pytest.fixture
+def content_only_chunk() -> dict:
+    return {
+        "chunk_id": "chunk::srd_35::combat::003_aoo_content_only",
+        "document_id": "srd_35::combat::003_aoo_content_only",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Threatened Squares"],
+            "source_location": "Combat.rtf#003_aoo_content_only",
+        },
+        "chunk_type": "subsection",
+        "content": "Sometimes movement provokes an attack of opportunity from a foe.",
+    }
+
+
+def _write_chunk(path: Path, chunk: dict) -> Path:
+    path.write_text(json.dumps(chunk), encoding="utf-8")
+    return path
 
 
 def test_contract_exports_lexical_types() -> None:
@@ -45,31 +114,30 @@ def test_contract_exports_lexical_types() -> None:
     assert candidate.score_direction == "lower_is_better"
 
 
-@pytest.fixture
-def sample_chunk() -> dict:
-    return {
-        "chunk_id": "chunk::srd_35::combat::001_attack_of_opportunity",
-        "document_id": "srd_35::combat::001_attack_of_opportunity",
-        "source_ref": {
-            "source_id": "srd_35",
-            "title": "System Reference Document",
-            "edition": "3.5e",
-            "source_type": "srd",
-            "authority_level": "official_reference",
-        },
-        "locator": {
-            "section_path": ["Combat", "Attack of Opportunity"],
-            "source_location": "Combat.rtf#001_attack_of_opportunity",
-        },
-        "chunk_type": "rule_section",
-        "content": "An attack of opportunity is a single melee attack.",
-    }
+def test_from_query_normalization_adapts_real_payload() -> None:
+    payload = normalize_query("fighter hp")
+
+    query = NormalizedQuery.from_query_normalization(payload)
+
+    assert query.raw_query == "fighter hp"
+    assert query.normalized_text == "fighter hit points"
+    assert query.tokens == ["fighter", "hit points"]
+    assert query.aliases_applied == [{"source": "hp", "target": "hit points"}]
+
+
+def test_from_query_normalization_requires_expected_keys() -> None:
+    with pytest.raises(KeyError):
+        NormalizedQuery.from_query_normalization(
+            {
+                "original_query": "fighter hp",
+                "normalized_text": "fighter hit points",
+            }
+        )
 
 
 def test_build_chunk_index_creates_fts_and_metadata_tables(tmp_path, sample_chunk) -> None:
     db_path = tmp_path / "retrieval.db"
-    chunk_path = tmp_path / "attack_of_opportunity.json"
-    chunk_path.write_text(json.dumps(sample_chunk), encoding="utf-8")
+    chunk_path = _write_chunk(tmp_path / "attack_of_opportunity.json", sample_chunk)
 
     build_chunk_index(db_path, [chunk_path])
 
@@ -95,7 +163,97 @@ def test_build_chunk_index_creates_fts_and_metadata_tables(tmp_path, sample_chun
     assert json.loads(metadata_row[3])["section_path"] == ["Combat", "Attack of Opportunity"]
 
 
-def test_build_match_signals_tracks_exact_and_protected_phrases(sample_chunk) -> None:
+def test_search_chunk_index_returns_ranked_candidates_from_fts(tmp_path, sample_chunk) -> None:
+    db_path = tmp_path / "retrieval.db"
+    aoo_path = _write_chunk(tmp_path / "attack_of_opportunity.json", sample_chunk)
+    turn_chunk = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::combat::004_turn_undead",
+        "document_id": "srd_35::combat::004_turn_undead",
+        "locator": {
+            "section_path": ["Combat", "Turning Checks"],
+            "source_location": "Combat.rtf#004_turn_undead",
+        },
+        "content": "Turning undead is a supernatural ability.",
+    }
+    turn_path = _write_chunk(tmp_path / "turn_undead.json", turn_chunk)
+
+    build_chunk_index(db_path, [aoo_path, turn_path])
+    results = search_chunk_index(db_path, "\"attack of opportunity\"", top_k=2)
+
+    assert [result["rank"] for result in results] == [1]
+    assert results[0]["chunk_id"] == sample_chunk["chunk_id"]
+    assert results[0]["raw_score"] <= 0
+
+
+def test_search_chunk_index_supports_real_corpus_turn_undead_recall(tmp_path) -> None:
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = Path("data/chunks/srd_35/combatii__029_turning_checks.json")
+
+    build_chunk_index(db_path, [chunk_path])
+    results = search_chunk_index(db_path, "\"turn undead\"", top_k=3)
+
+    assert results
+    assert results[0]["chunk_id"] == "chunk::srd_35::combatii::029_turning_checks"
+
+
+def test_search_chunk_index_supports_real_corpus_bonus_feats_recall(tmp_path) -> None:
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = Path("data/chunks/srd_35/feats__004_fighter_bonus_feats.json")
+
+    build_chunk_index(db_path, [chunk_path])
+    results = search_chunk_index(db_path, "\"fighter bonus feats\"", top_k=3)
+
+    assert results
+    assert results[0]["chunk_id"] == "chunk::srd_35::feats::004_fighter_bonus_feats"
+
+
+def test_build_chunk_index_rebuilds_cleanly(tmp_path, sample_chunk) -> None:
+    db_path = tmp_path / "retrieval.db"
+    first = _write_chunk(tmp_path / "first.json", sample_chunk)
+    second_chunk = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::combat::005_turn_undead",
+        "document_id": "srd_35::combat::005_turn_undead",
+        "locator": {
+            "section_path": ["Combat", "Turning Checks"],
+            "source_location": "Combat.rtf#005_turn_undead",
+        },
+        "content": "Turn undead lets clerics repel undead creatures.",
+    }
+    second = _write_chunk(tmp_path / "second.json", second_chunk)
+
+    build_chunk_index(db_path, [first])
+    build_chunk_index(db_path, [second])
+
+    stale = search_chunk_index(db_path, "\"attack of opportunity\"", top_k=3)
+    fresh = search_chunk_index(db_path, "\"turn undead\"", top_k=3)
+
+    assert stale == []
+    assert fresh[0]["chunk_id"] == second_chunk["chunk_id"]
+
+
+def test_build_chunk_index_raises_on_malformed_chunk_shape(tmp_path) -> None:
+    db_path = tmp_path / "retrieval.db"
+    broken_chunk = {"chunk_id": "broken"}
+    broken_path = _write_chunk(tmp_path / "broken.json", broken_chunk)
+
+    with pytest.raises(KeyError):
+        build_chunk_index(db_path, [broken_path])
+
+
+def test_create_schema_raises_when_fts5_is_unavailable(monkeypatch) -> None:
+    class FakeConnection:
+        def execute(self, sql: str):
+            if "CREATE VIRTUAL TABLE chunks_fts USING fts5" in sql:
+                raise sqlite3.OperationalError("no such module: fts5")
+            return None
+
+    with pytest.raises(RuntimeError, match="FTS5 support is required"):
+        _create_schema(FakeConnection())
+
+
+def test_build_match_signals_tracks_phrase_hits_in_title_only(title_only_chunk) -> None:
     query = NormalizedQuery(
         raw_query="attack of opportunity",
         normalized_text="attack of opportunity",
@@ -104,14 +262,50 @@ def test_build_match_signals_tracks_exact_and_protected_phrases(sample_chunk) ->
         aliases_applied=[],
     )
 
-    signals = build_match_signals(query, sample_chunk, "Combat Attack of Opportunity")
+    signals = build_match_signals(query, title_only_chunk, "Combat Attack of Opportunity")
 
     assert signals["exact_phrase_hits"] == ["attack of opportunity"]
     assert signals["protected_phrase_hits"] == ["attack of opportunity"]
     assert signals["section_path_hit"] is True
+    assert signals["token_overlap_count"] == 3
 
 
-def test_build_match_signals_counts_token_overlap(sample_chunk) -> None:
+def test_build_match_signals_tracks_phrase_hits_in_content_only(content_only_chunk) -> None:
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+
+    signals = build_match_signals(query, content_only_chunk, "Combat Threatened Squares")
+
+    assert signals["exact_phrase_hits"] == ["attack of opportunity"]
+    assert signals["protected_phrase_hits"] == ["attack of opportunity"]
+    assert signals["section_path_hit"] is False
+
+
+def test_build_match_signals_reports_overlapping_protected_phrases(sample_chunk) -> None:
+    query = NormalizedQuery(
+        raw_query="fighter bab",
+        normalized_text="fighter base attack bonus",
+        tokens=["fighter", "base attack bonus"],
+        protected_phrases=["base attack bonus", "attack bonus"],
+        aliases_applied=[{"source": "bab", "target": "base attack bonus"}],
+    )
+    chunk = {
+        **sample_chunk,
+        "content": "A fighter's base attack bonus determines attack bonus progression.",
+    }
+
+    signals = build_match_signals(query, chunk, "Classes Fighter")
+
+    assert signals["protected_phrase_hits"] == ["base attack bonus", "attack bonus"]
+    assert signals["token_overlap_count"] >= 3
+
+
+def test_build_match_signals_counts_token_overlap_across_section_and_content(sample_chunk) -> None:
     query = NormalizedQuery(
         raw_query="single melee attack",
         normalized_text="single melee attack",

--- a/tests/test_retrieval_filters.py
+++ b/tests/test_retrieval_filters.py
@@ -10,8 +10,6 @@ from scripts.retrieval.filters import (
 )
 
 
-# ── Helpers ──────────────────────────────────────────────────────
-
 def _make_source_ref(edition="3.5e", source_type="srd", authority="official_reference", source_id="srd_35"):
     return {
         "source_id": source_id,
@@ -23,7 +21,6 @@ def _make_source_ref(edition="3.5e", source_type="srd", authority="official_refe
 
 
 def _chunk(edition="3.5e", source_type="srd", authority="official_reference", source_id="srd_35"):
-    """Build a realistic chunk matching data/chunks/srd_35/*.json shape."""
     return {
         "chunk_id": f"chunk::{source_id}::test::001",
         "document_id": f"{source_id}::test::001",
@@ -35,7 +32,6 @@ def _chunk(edition="3.5e", source_type="srd", authority="official_reference", so
 
 
 def _flat_meta(edition="3.5e", source_type="srd", authority="official_reference", source_id="srd_35"):
-    """Flat metadata dict (no source_ref nesting) for fallback tests."""
     return {
         "edition": edition,
         "source_type": source_type,
@@ -44,24 +40,17 @@ def _flat_meta(edition="3.5e", source_type="srd", authority="official_reference"
     }
 
 
-# ── Constraints from source registry ────────────────────────────
-
 def test_build_constraints_from_registry():
-    """Default constraints derive from source_registry.yaml."""
     c = build_constraints()
     assert isinstance(c, RetrievalConstraints)
-    # The only admitted (non-planned_later) source is srd_35
     assert "3.5e" in c.editions
     assert "srd" in c.source_types
     assert "official_reference" in c.authority_levels
 
 
 def test_build_constraints_skips_planned_later():
-    """planned_later sources should not widen the filter allowlists."""
     c = build_constraints()
-    # core_rulebook exists in registry but only on planned_later entries
     assert "core_rulebook" not in c.source_types
-    # official exists only on planned_later entries
     assert "official" not in c.authority_levels
 
 
@@ -71,7 +60,6 @@ def test_build_constraints_excluded_source_ids():
 
 
 def test_build_constraints_rejects_empty_registry(tmp_path):
-    """An empty YAML file should raise a clear ValueError, not AttributeError."""
     bad = tmp_path / "empty.yaml"
     bad.write_text("", encoding="utf-8")
     with pytest.raises(ValueError, match="must be a YAML mapping"):
@@ -79,14 +67,11 @@ def test_build_constraints_rejects_empty_registry(tmp_path):
 
 
 def test_build_constraints_rejects_non_list_sources(tmp_path):
-    """A 'sources' key that isn't a list should raise a clear ValueError."""
     bad = tmp_path / "bad.yaml"
     bad.write_text("sources: not_a_list\n", encoding="utf-8")
     with pytest.raises(ValueError, match="expected a list"):
         build_constraints(registry_path=bad)
 
-
-# ── Accepts / rejects ───────────────────────────────────────────
 
 @pytest.fixture
 def default_constraints():
@@ -124,8 +109,6 @@ def test_rejection_reason_none_when_accepted(default_constraints):
     assert default_constraints.rejection_reason(_chunk()) is None
 
 
-# ── apply_filters integration ────────────────────────────────────
-
 def test_apply_filters_separates_accepted_and_rejected():
     candidates = [
         _chunk(),
@@ -156,7 +139,6 @@ def test_apply_filters_not_empty_when_some_accepted():
 
 
 def test_apply_filters_with_flat_metadata():
-    """Flat dicts without source_ref still work via fallback."""
     candidates = [_flat_meta(), _flat_meta(edition="5e")]
     result = apply_filters(candidates)
     assert len(result.accepted) == 1
@@ -170,10 +152,7 @@ def test_apply_filters_empty_candidates():
     assert result.empty is True
 
 
-# ── Real corpus chunk ────────────────────────────────────────────
-
 def test_accepts_real_corpus_chunk(default_constraints):
-    """A chunk shaped exactly like data/chunks/srd_35/*.json must pass."""
     real_chunk = {
         "chunk_id": "chunk::srd_35::abilitiesandconditions::001_abilitiesandconditions",
         "document_id": "srd_35::abilitiesandconditions::001_abilitiesandconditions",
@@ -197,8 +176,6 @@ def test_accepts_real_corpus_chunk(default_constraints):
     assert default_constraints.rejection_reason(real_chunk) is None
 
 
-# ── Parametrized edition / source-type coverage ──────────────────
-
 @pytest.mark.parametrize("edition", ["3e", "4e", "5e", "5.1e", "2e"])
 def test_non_35e_editions_rejected_by_default(default_constraints, edition):
     assert default_constraints.accepts(_chunk(edition=edition)) is False
@@ -206,5 +183,4 @@ def test_non_35e_editions_rejected_by_default(default_constraints, edition):
 
 @pytest.mark.parametrize("source_type", ["curated_commentary", "personal_note", "core_rulebook"])
 def test_non_admitted_source_types_rejected(default_constraints, source_type):
-    """source_types only on planned_later entries are not admitted."""
     assert default_constraints.accepts(_chunk(source_type=source_type)) is False


### PR DESCRIPTION
## Summary
Lands the first infrastructure slice for #33:
typed lexical contracts, SQLite FTS index primitives, initial match signals, and focused tests.

Follow-up work will wire runtime lexical search, candidate generation, and broader recall coverage.

## Evidence
Implemented files:
- `scripts/retrieval/contracts.py`
- `scripts/retrieval/filters.py`
- `scripts/retrieval/lexical_index.py`
- `scripts/retrieval/match_signals.py`
- `scripts/retrieval/__init__.py`
- `tests/test_lexical_retrieval.py`
- `tests/test_retrieval_filters.py`

Verification run on 2026-04-16 in `D:\aiProjects\workspaces\dndKnowledgeBot\.worktrees\issue-33-lexical-retrieval`:

```text
$env:PYTHONPATH='.'; pytest tests/test_lexical_retrieval.py tests/test_query_normalization.py tests/test_retrieval_term_assets.py tests/test_retrieval_filters.py -v
============================= test session starts =============================
platform win32 -- Python 3.13.12, pytest-9.0.3, pluggy-1.6.0
collected 60 items

18 tests from tests/test_lexical_retrieval.py PASSED
8 tests from tests/test_query_normalization.py PASSED
7 tests from tests/test_retrieval_term_assets.py PASSED
27 tests from tests/test_retrieval_filters.py PASSED

============================= 60 passed in 0.34s ==============================
```

Retrieval-specific evidence in this PR:
- adapter coverage for `NormalizedQuery.from_query_normalization(...)`
- real FTS query execution with ranked candidate return
- empty-match behavior and `top_k=0`
- multi-candidate BM25 ordering
- real-corpus recall for `turn undead` and `fighter bonus feats`
- rebuild behavior, malformed chunk input, and missing FTS5 support
- title-only hits, content-only hits, overlapping protected phrases, and multiword token overlap
- preserved `apply_filters`, `build_constraints`, `FilterResult`, and `RetrievalConstraints` in the public package API after Issue #32 merged

## Notes
- The FTS helper documents that `query_text` must already be a valid FTS5 `MATCH` expression. Sanitizing raw user input belongs in the higher-level retriever layer.
- The JOIN remains acceptable for Phase 1 corpus size; rowid-based optimization can wait for a later slice if needed.
- This PR is intentionally scoped as infrastructure for #33, not the full lexical retriever.

Refs #33