### PR TITLE
feat(retrieval): implement lexical retriever end-to-end path

### DIFF
--- a/docs/plans/2026-04-20-lexical-retriever-end-to-end.md
+++ b/docs/plans/2026-04-20-lexical-retriever-end-to-end.md
@@ -22,12 +22,13 @@ def retrieve_lexical(
 
 It wires together the existing primitives in this order:
 
-1. **Build FTS expression** from `NormalizedQuery` — protected phrases as `"quoted phrases"`, remaining tokens OR'd
-2. **Over-fetch** from `search_chunk_index()` at `top_k * 2`
-3. **Compute real match signals** via `build_match_signals()` for each candidate
-4. **Apply hard filters** via `RetrievalConstraints.accepts()`
-5. **Truncate** to `top_k` and re-rank (1-indexed)
-6. **Return** `list[LexicalCandidate]` with populated signals
+1. **Build FTS expression** from `NormalizedQuery` — all tokens double-quoted to prevent FTS5 operator injection, joined with `OR`
+2. **Over-fetch** from `_search_raw()` at `top_k * 2`
+3. **Apply hard filters** via `RetrievalConstraints.accepts()`
+4. **Compute real match signals** via `build_match_signals()` for each candidate
+5. **Domain-aware rerank** via `_composite_score()` — combines BM25 with signal boosts (section path hit, exact/protected phrase hits, token overlap)
+6. **Truncate** to `top_k` and assign 1-indexed ranks
+7. **Return** `list[LexicalCandidate]` with populated signals
 
 The DB path defaults to `data/index/srd_35/lexical.db` relative to repo root.
 
@@ -36,14 +37,14 @@ The DB path defaults to `data/index/srd_35/lexical.db` relative to repo root.
 A private helper `_build_fts_expression(query: NormalizedQuery) -> str`:
 
 1. Start with `query.tokens` (already split with protected phrases preserved as multi-word tokens).
-2. For each token: if it appears in `query.protected_phrases`, wrap as `"quoted phrase"`. Otherwise emit as a bare term.
+2. Double-quote every token to prevent FTS5 operator injection (bare `not`, `and`, etc.).
 3. If the full `normalized_text` differs from any single token, prepend it as a quoted phrase so the full query gets phrase-match priority from BM25.
 4. Join all parts with `OR`.
 
 Example: query `"fighter hit points"` with protected phrase `"hit points"` and tokens `["fighter", "hit points"]` produces:
 
 ```
-"fighter hit points" OR fighter OR "hit points"
+"fighter hit points" OR "fighter" OR "hit points"
 ```
 
 Full-phrase matches rank highest via BM25, partial matches still recalled.
@@ -53,6 +54,17 @@ Full-phrase matches rank highest via BM25, partial matches still recalled.
 After FTS returns raw candidates, each candidate is hydrated with real match signals via `build_match_signals(query, chunk_dict, section_path_text)`.
 
 The existing `search_chunk_index()` returns `LexicalCandidate` with empty placeholder signals. Rather than changing that public API, the retriever uses a package-private variant that returns raw row data (including `content` and `section_path_text`) alongside the candidate fields. The retriever then constructs a minimal chunk dict from the row data and calls `build_match_signals()`.
+
+## Domain-Aware Reranking
+
+After match signals are computed, candidates are sorted by a composite score via `_composite_score(raw_score, signals)`. BM25 is lower-is-better, so boosts subtract from the score:
+
+- Section path hit: -2.0
+- Exact phrase hit: -1.5 per hit
+- Protected phrase hit: -1.0 per hit
+- Token overlap: -0.1 per overlapping term
+
+This keeps BM25 as the primary signal while letting domain-aware match signals promote candidates that are structurally or terminologically relevant.
 
 ## Hard Filter Strategy
 
@@ -87,5 +99,5 @@ New tests:
 - Semantic or vector retrieval
 - Reranking model
 - Hierarchical candidate shaping (#44)
-- Domain-aware scoring beyond match signals (#47)
+- Full domain-aware scoring model beyond lightweight composite reranking (#47)
 - Candidate deduplication (#34)

--- a/docs/plans/2026-04-20-lexical-retriever-end-to-end.md
+++ b/docs/plans/2026-04-20-lexical-retriever-end-to-end.md
@@ -1,0 +1,91 @@
+# Lexical Retriever End-to-End Path
+
+Issue: #43 — Parent: #33
+
+## Goal
+
+Wire the existing lexical retrieval primitives (FTS index, query normalization, match signals, hard filters) into a single `retrieve_lexical()` function that goes from a normalized query to a ranked list of `LexicalCandidate` objects with populated match signals.
+
+## Architecture
+
+A single new module `scripts/retrieval/lexical_retriever.py` with one public function:
+
+```python
+def retrieve_lexical(
+    query: NormalizedQuery,
+    *,
+    constraints: RetrievalConstraints | None = None,
+    db_path: Path | None = None,
+    top_k: int = 10,
+) -> list[LexicalCandidate]:
+```
+
+It wires together the existing primitives in this order:
+
+1. **Build FTS expression** from `NormalizedQuery` — protected phrases as `"quoted phrases"`, remaining tokens OR'd
+2. **Over-fetch** from `search_chunk_index()` at `top_k * 2`
+3. **Compute real match signals** via `build_match_signals()` for each candidate
+4. **Apply hard filters** via `RetrievalConstraints.accepts()`
+5. **Truncate** to `top_k` and re-rank (1-indexed)
+6. **Return** `list[LexicalCandidate]` with populated signals
+
+The DB path defaults to `data/index/srd_35/lexical.db` relative to repo root.
+
+## FTS Expression Builder
+
+A private helper `_build_fts_expression(query: NormalizedQuery) -> str`:
+
+1. Start with `query.tokens` (already split with protected phrases preserved as multi-word tokens).
+2. For each token: if it appears in `query.protected_phrases`, wrap as `"quoted phrase"`. Otherwise emit as a bare term.
+3. If the full `normalized_text` differs from any single token, prepend it as a quoted phrase so the full query gets phrase-match priority from BM25.
+4. Join all parts with `OR`.
+
+Example: query `"fighter hit points"` with protected phrase `"hit points"` and tokens `["fighter", "hit points"]` produces:
+
+```
+"fighter hit points" OR fighter OR "hit points"
+```
+
+Full-phrase matches rank highest via BM25, partial matches still recalled.
+
+## Match Signal Hydration
+
+After FTS returns raw candidates, each candidate is hydrated with real match signals via `build_match_signals(query, chunk_dict, section_path_text)`.
+
+The existing `search_chunk_index()` returns `LexicalCandidate` with empty placeholder signals. Rather than changing that public API, the retriever uses a package-private variant that returns raw row data (including `content` and `section_path_text`) alongside the candidate fields. The retriever then constructs a minimal chunk dict from the row data and calls `build_match_signals()`.
+
+## Hard Filter Strategy
+
+Post-retrieval filtering with over-fetch. The retriever requests `top_k * 2` from FTS, then runs `RetrievalConstraints.accepts()` on each candidate to filter, then truncates to `top_k`.
+
+This is appropriate for Phase 1: the corpus is single-edition SRD-only, so nearly all chunks pass. Over-fetching is cheap, keeps FTS query construction simple, and the post-filter safety net is already built. FTS column filters can be added later if multi-source support requires it.
+
+## Files Changed
+
+New:
+- `scripts/retrieval/lexical_retriever.py` — `retrieve_lexical()` and `_build_fts_expression()`
+
+Modified:
+- `scripts/retrieval/__init__.py` — export `retrieve_lexical`
+- `scripts/retrieval/lexical_index.py` — add package-private `_search_chunk_index_raw()` that returns row data for signal hydration
+
+New tests:
+- `tests/test_lexical_retriever.py`
+
+## Test Plan
+
+- FTS expression builder produces correct expressions for single-token, multi-token, and protected-phrase queries
+- `retrieve_lexical()` returns `LexicalCandidate` objects with populated (non-placeholder) match signals
+- Hard filters reject candidates that don't match constraints
+- Over-fetch ensures `top_k` results survive filtering when some candidates are rejected
+- Real corpus recall: `turn undead`, `attack of opportunity`, `fighter bonus feats` return expected chunks
+- Empty query or no-match query returns empty list
+- Default DB path resolves correctly
+
+## Out of Scope
+
+- Semantic or vector retrieval
+- Reranking model
+- Hierarchical candidate shaping (#44)
+- Domain-aware scoring beyond match signals (#47)
+- Candidate deduplication (#34)

--- a/docs/plans/2026-04-20-lexical-retriever-implementation.md
+++ b/docs/plans/2026-04-20-lexical-retriever-implementation.md
@@ -1,0 +1,677 @@
+# Lexical Retriever End-to-End Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire existing lexical retrieval primitives into a `retrieve_lexical()` function that goes from normalized query to ranked `LexicalCandidate` objects with populated match signals.
+
+**Architecture:** A new `scripts/retrieval/lexical_retriever.py` module composes FTS expression building, over-fetch search, match signal hydration, hard filtering, and result truncation. A package-private `_search_raw()` helper in `lexical_index.py` exposes row data (including content and section_path_text) needed for signal hydration without changing the existing public API.
+
+**Tech Stack:** Python 3.13, SQLite FTS5, pytest, existing `scripts/retrieval/` modules
+
+**Spec:** `docs/plans/2026-04-20-lexical-retriever-end-to-end.md`
+
+---
+
+### Task 1: Add `_search_raw()` to `lexical_index.py`
+
+**Files:**
+- Modify: `scripts/retrieval/lexical_index.py`
+- Test: `tests/test_lexical_retriever.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_lexical_retriever.py` with a test for the raw search helper:
+
+```python
+"""Tests for Issue #43 lexical retriever end-to-end path."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.retrieval import NormalizedQuery
+from scripts.retrieval.lexical_index import _search_raw, build_chunk_index
+
+
+@pytest.fixture
+def sample_chunk() -> dict:
+    return {
+        "chunk_id": "chunk::srd_35::combat::001_attack_of_opportunity",
+        "document_id": "srd_35::combat::001_attack_of_opportunity",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "source_location": "Combat.rtf#001_attack_of_opportunity",
+        },
+        "chunk_type": "rule_section",
+        "content": "An attack of opportunity is a single melee attack.",
+    }
+
+
+def _write_chunk(path: Path, chunk: dict) -> Path:
+    path.write_text(json.dumps(chunk), encoding="utf-8")
+    return path
+
+
+def test_search_raw_returns_row_data_with_content(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    rows = _search_raw(db_path, '"attack of opportunity"', top_k=3)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["chunk_id"] == sample_chunk["chunk_id"]
+    assert row["content"] == sample_chunk["content"]
+    assert row["section_path_text"] == "Combat Attack of Opportunity"
+    assert row["source_ref"] == sample_chunk["source_ref"]
+    assert row["locator"] == sample_chunk["locator"]
+    assert row["raw_score"] <= 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retriever.py::test_search_raw_returns_row_data_with_content -v`
+Expected: FAIL — `ImportError: cannot import name '_search_raw'`
+
+- [ ] **Step 3: Write `_search_raw()` implementation**
+
+Add to `scripts/retrieval/lexical_index.py` after `search_chunk_index`:
+
+```python
+def _search_raw(db_path: Path, query_text: str, *, top_k: int = 5) -> list[dict]:
+    """Return raw row dicts for signal hydration. Package-private."""
+    if top_k <= 0:
+        return []
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute(
+            """
+            SELECT
+                chunk_metadata.chunk_id,
+                chunk_metadata.document_id,
+                chunk_metadata.section_path_text,
+                chunk_metadata.chunk_type,
+                chunk_metadata.source_ref_json,
+                chunk_metadata.locator_json,
+                chunk_metadata.content,
+                bm25(chunks_fts) AS raw_score
+            FROM chunks_fts
+            JOIN chunk_metadata ON chunk_metadata.chunk_id = chunks_fts.chunk_id
+            WHERE chunks_fts MATCH ?
+            ORDER BY raw_score ASC
+            LIMIT ?
+            """,
+            (query_text, top_k),
+        ).fetchall()
+
+    return [
+        {
+            "chunk_id": row[0],
+            "document_id": row[1],
+            "section_path_text": row[2],
+            "chunk_type": row[3],
+            "source_ref": json.loads(row[4]),
+            "locator": json.loads(row[5]),
+            "content": row[6],
+            "raw_score": float(row[7]),
+        }
+        for row in rows
+    ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retriever.py::test_search_raw_returns_row_data_with_content -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/retrieval/lexical_index.py tests/test_lexical_retriever.py
+git commit -m "feat(retrieval): add _search_raw for signal hydration"
+```
+
+---
+
+### Task 2: Implement `_build_fts_expression()`
+
+**Files:**
+- Create: `scripts/retrieval/lexical_retriever.py`
+- Test: `tests/test_lexical_retriever.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_lexical_retriever.py`:
+
+```python
+from scripts.retrieval.lexical_retriever import _build_fts_expression
+
+
+def test_fts_expression_single_bare_token():
+    query = NormalizedQuery(
+        raw_query="fighter",
+        normalized_text="fighter",
+        tokens=["fighter"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    assert _build_fts_expression(query) == "fighter"
+
+
+def test_fts_expression_protected_phrase_quoted():
+    query = NormalizedQuery(
+        raw_query="hit points",
+        normalized_text="hit points",
+        tokens=["hit points"],
+        protected_phrases=["hit points"],
+        aliases_applied=[],
+    )
+    assert _build_fts_expression(query) == '"hit points"'
+
+
+def test_fts_expression_mixed_tokens_and_protected_phrases():
+    query = NormalizedQuery(
+        raw_query="fighter hp",
+        normalized_text="fighter hit points",
+        tokens=["fighter", "hit points"],
+        protected_phrases=["hit points"],
+        aliases_applied=[{"source": "hp", "target": "hit points"}],
+    )
+    result = _build_fts_expression(query)
+    assert result == '"fighter hit points" OR fighter OR "hit points"'
+
+
+def test_fts_expression_multiple_bare_tokens():
+    query = NormalizedQuery(
+        raw_query="melee damage",
+        normalized_text="melee damage",
+        tokens=["melee", "damage"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    result = _build_fts_expression(query)
+    assert result == '"melee damage" OR melee OR damage'
+
+
+def test_fts_expression_empty_tokens_returns_empty_string():
+    query = NormalizedQuery(
+        raw_query="",
+        normalized_text="",
+        tokens=[],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    assert _build_fts_expression(query) == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retriever.py -k "fts_expression" -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'scripts.retrieval.lexical_retriever'`
+
+- [ ] **Step 3: Write `_build_fts_expression()` implementation**
+
+Create `scripts/retrieval/lexical_retriever.py`:
+
+```python
+"""End-to-end lexical retriever for Phase 1."""
+from __future__ import annotations
+
+from .contracts import NormalizedQuery
+
+
+def _build_fts_expression(query: NormalizedQuery) -> str:
+    """Build an FTS5 MATCH expression from a normalized query."""
+    if not query.tokens:
+        return ""
+
+    protected_set = set(query.protected_phrases)
+    parts: list[str] = []
+
+    for token in query.tokens:
+        if token in protected_set:
+            parts.append(f'"{token}"')
+        else:
+            parts.append(token)
+
+    # Prepend the full normalized text as a quoted phrase when it differs
+    # from any single token — gives BM25 full-phrase match priority.
+    if len(query.tokens) > 1:
+        full_phrase = f'"{query.normalized_text}"'
+        parts.insert(0, full_phrase)
+
+    return " OR ".join(parts)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retriever.py -k "fts_expression" -v`
+Expected: PASS (all 5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/retrieval/lexical_retriever.py tests/test_lexical_retriever.py
+git commit -m "feat(retrieval): add FTS expression builder"
+```
+
+---
+
+### Task 3: Implement `retrieve_lexical()`
+
+**Files:**
+- Modify: `scripts/retrieval/lexical_retriever.py`
+- Test: `tests/test_lexical_retriever.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_lexical_retriever.py`:
+
+```python
+from scripts.retrieval import LexicalCandidate, build_constraints
+from scripts.retrieval.lexical_retriever import retrieve_lexical
+
+
+def test_retrieve_lexical_returns_candidates_with_populated_signals(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 1
+    candidate = results[0]
+    assert isinstance(candidate, LexicalCandidate)
+    assert candidate.chunk_id == sample_chunk["chunk_id"]
+    assert candidate.rank == 1
+    assert candidate.match_signals["exact_phrase_hits"] == ["attack of opportunity"]
+    assert candidate.match_signals["protected_phrase_hits"] == ["attack of opportunity"]
+    assert candidate.match_signals["section_path_hit"] is True
+    assert candidate.match_signals["token_overlap_count"] >= 3
+
+
+def test_retrieve_lexical_filters_out_non_matching_editions(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_5e = {
+        **sample_chunk,
+        "chunk_id": "chunk::phb_5e::combat::001",
+        "source_ref": {
+            **sample_chunk["source_ref"],
+            "source_id": "phb_5e",
+            "edition": "5e",
+            "source_type": "core_rulebook",
+            "authority_level": "official",
+        },
+    }
+    path_35 = _write_chunk(tmp_path / "aoo_35.json", sample_chunk)
+    path_5e = _write_chunk(tmp_path / "aoo_5e.json", chunk_5e)
+    build_chunk_index(db_path, [path_35, path_5e])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    constraints = build_constraints()
+    results = retrieve_lexical(query, constraints=constraints, db_path=db_path, top_k=5)
+
+    assert all(r.source_ref["edition"] == "3.5e" for r in results)
+    assert len(results) == 1
+
+
+def test_retrieve_lexical_returns_empty_for_no_match(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="psionics",
+        normalized_text="psionics",
+        tokens=["psionics"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results == []
+
+
+def test_retrieve_lexical_empty_tokens_returns_empty(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="",
+        normalized_text="",
+        tokens=[],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results == []
+
+
+def test_retrieve_lexical_respects_top_k(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunks = []
+    for i in range(5):
+        chunk = {
+            **sample_chunk,
+            "chunk_id": f"chunk::srd_35::combat::{i:03d}_attack",
+            "document_id": f"srd_35::combat::{i:03d}_attack",
+            "content": f"An attack of opportunity is a melee attack variant {i}.",
+        }
+        chunks.append(_write_chunk(tmp_path / f"chunk_{i}.json", chunk))
+    build_chunk_index(db_path, chunks)
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=3)
+
+    assert len(results) == 3
+    assert [r.rank for r in results] == [1, 2, 3]
+
+
+def test_retrieve_lexical_reranks_after_filtering(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_35 = sample_chunk
+    chunk_5e = {
+        **sample_chunk,
+        "chunk_id": "chunk::phb_5e::combat::001",
+        "document_id": "phb_5e::combat::001",
+        "source_ref": {
+            **sample_chunk["source_ref"],
+            "source_id": "phb_5e",
+            "edition": "5e",
+            "source_type": "core_rulebook",
+            "authority_level": "official",
+        },
+    }
+    path_35 = _write_chunk(tmp_path / "aoo_35.json", chunk_35)
+    path_5e = _write_chunk(tmp_path / "aoo_5e.json", chunk_5e)
+    build_chunk_index(db_path, [path_35, path_5e])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    constraints = build_constraints()
+    results = retrieve_lexical(query, constraints=constraints, db_path=db_path, top_k=5)
+
+    assert len(results) == 1
+    assert results[0].rank == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retriever.py -k "retrieve_lexical" -v`
+Expected: FAIL — `ImportError: cannot import name 'retrieve_lexical'`
+
+- [ ] **Step 3: Write `retrieve_lexical()` implementation**
+
+Add to `scripts/retrieval/lexical_retriever.py`:
+
+```python
+from pathlib import Path
+
+from .contracts import LexicalCandidate, NormalizedQuery
+from .filters import RetrievalConstraints, build_constraints
+from .lexical_index import _search_raw
+from .match_signals import build_match_signals
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB_PATH = REPO_ROOT / "data" / "index" / "srd_35" / "lexical.db"
+
+
+def retrieve_lexical(
+    query: NormalizedQuery,
+    *,
+    constraints: RetrievalConstraints | None = None,
+    db_path: Path | None = None,
+    top_k: int = 10,
+) -> list[LexicalCandidate]:
+    """Run end-to-end lexical retrieval from normalized query to ranked candidates."""
+    fts_expression = _build_fts_expression(query)
+    if not fts_expression:
+        return []
+
+    if constraints is None:
+        constraints = build_constraints()
+    if db_path is None:
+        db_path = DEFAULT_DB_PATH
+
+    raw_rows = _search_raw(db_path, fts_expression, top_k=top_k * 2)
+
+    candidates: list[LexicalCandidate] = []
+    for row in raw_rows:
+        if not constraints.accepts(row):
+            continue
+
+        chunk_dict = {"content": row["content"], "source_ref": row["source_ref"]}
+        signals = build_match_signals(query, chunk_dict, row["section_path_text"])
+
+        candidates.append(
+            LexicalCandidate(
+                chunk_id=row["chunk_id"],
+                document_id=row["document_id"],
+                rank=0,
+                raw_score=row["raw_score"],
+                score_direction="lower_is_better",
+                chunk_type=row["chunk_type"],
+                source_ref=row["source_ref"],
+                locator=row["locator"],
+                match_signals=signals,
+            )
+        )
+
+    truncated = candidates[:top_k]
+    return [
+        LexicalCandidate(
+            chunk_id=c.chunk_id,
+            document_id=c.document_id,
+            rank=rank,
+            raw_score=c.raw_score,
+            score_direction=c.score_direction,
+            chunk_type=c.chunk_type,
+            source_ref=c.source_ref,
+            locator=c.locator,
+            match_signals=c.match_signals,
+        )
+        for rank, c in enumerate(truncated, start=1)
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retriever.py -k "retrieve_lexical" -v`
+Expected: PASS (all 6 tests)
+
+- [ ] **Step 5: Run the full test file**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retriever.py -v`
+Expected: PASS (all 12 tests — 1 from Task 1 + 5 from Task 2 + 6 from Task 3)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/retrieval/lexical_retriever.py tests/test_lexical_retriever.py
+git commit -m "feat(retrieval): implement retrieve_lexical end-to-end path"
+```
+
+---
+
+### Task 4: Export `retrieve_lexical` and add real-corpus recall tests
+
+**Files:**
+- Modify: `scripts/retrieval/__init__.py`
+- Modify: `tests/test_lexical_retriever.py`
+
+- [ ] **Step 1: Update `__init__.py` exports**
+
+Add the import and export for `retrieve_lexical` in `scripts/retrieval/__init__.py`:
+
+```python
+from .contracts import LexicalCandidate, NormalizedQuery
+from .filters import (
+    apply_filters,
+    build_constraints,
+    FilterResult,
+    RetrievalConstraints,
+)
+from .lexical_retriever import retrieve_lexical
+from .query_normalization import normalize_query
+from .term_assets import get_default_term_assets, load_term_assets
+
+__all__ = [
+    "apply_filters",
+    "build_constraints",
+    "FilterResult",
+    "get_default_term_assets",
+    "LexicalCandidate",
+    "load_term_assets",
+    "normalize_query",
+    "NormalizedQuery",
+    "retrieve_lexical",
+    "RetrievalConstraints",
+]
+```
+
+- [ ] **Step 2: Write real-corpus recall tests**
+
+Append to `tests/test_lexical_retriever.py`:
+
+```python
+from scripts.retrieval import normalize_query, retrieve_lexical as retrieve_lexical_public
+
+
+def _build_index_with_real_chunks(db_path: Path, chunk_filenames: list[str]) -> None:
+    chunk_dir = Path("data/chunks/srd_35")
+    chunk_paths = [chunk_dir / name for name in chunk_filenames]
+    build_chunk_index(db_path, chunk_paths)
+
+
+def test_real_corpus_recall_turn_undead(tmp_path):
+    db_path = tmp_path / "retrieval.db"
+    _build_index_with_real_chunks(db_path, ["combatii__029_turning_checks.json"])
+
+    payload = normalize_query("turn undead")
+    query = NormalizedQuery.from_query_normalization(payload)
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results
+    assert results[0].chunk_id == "chunk::srd_35::combatii::029_turning_checks"
+    assert results[0].match_signals["token_overlap_count"] >= 2
+
+
+def test_real_corpus_recall_attack_of_opportunity(tmp_path):
+    db_path = tmp_path / "retrieval.db"
+    _build_index_with_real_chunks(db_path, [
+        "combati__001_combati.json",
+        "combati__002_how_combat_works.json",
+        "combati__006_attacks_of_opportunity.json",
+    ])
+
+    payload = normalize_query("attack of opportunity")
+    query = NormalizedQuery.from_query_normalization(payload)
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results
+    chunk_ids = [r.chunk_id for r in results]
+    assert "chunk::srd_35::combati::006_attacks_of_opportunity" in chunk_ids
+
+
+def test_real_corpus_recall_fighter_bonus_feats(tmp_path):
+    db_path = tmp_path / "retrieval.db"
+    _build_index_with_real_chunks(db_path, ["feats__004_fighter_bonus_feats.json"])
+
+    payload = normalize_query("fighter bonus feats")
+    query = NormalizedQuery.from_query_normalization(payload)
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results
+    assert results[0].chunk_id == "chunk::srd_35::feats::004_fighter_bonus_feats"
+    assert results[0].match_signals["token_overlap_count"] >= 2
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retriever.py -v`
+Expected: PASS (all 15 tests)
+
+- [ ] **Step 4: Run the full existing test suite to check for regressions**
+
+Run: `PYTHONPATH=. pytest tests/test_lexical_retrieval.py tests/test_retrieval_filters.py tests/test_query_normalization.py tests/test_retrieval_term_assets.py -v`
+Expected: All existing tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/retrieval/__init__.py tests/test_lexical_retriever.py
+git commit -m "feat(retrieval): export retrieve_lexical, add real-corpus recall tests"
+```
+
+---
+
+### Task 5: Push branch and open PR
+
+**Files:** None (git operations only)
+
+- [ ] **Step 1: Run full test suite one final time**
+
+Run: `PYTHONPATH=. pytest tests/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin issue-43-lexical-retriever
+gh pr create --title "feat(retrieval): implement lexical retriever end-to-end path" --body "$(cat <<'EOF'
+## Summary
+Implements the end-to-end lexical retrieval path for #43 (child of #33):
+- `retrieve_lexical()` wires query normalization → FTS search → match signal hydration → hard filtering → ranked output
+- FTS expression builder converts `NormalizedQuery` into BM25-optimized MATCH expressions
+- `_search_raw()` helper exposes row data for signal hydration without changing existing public API
+- Real-corpus recall tests for `turn undead`, `attack of opportunity`, `fighter bonus feats`
+
+## Evidence
+- All new and existing tests pass
+- Candidates return with populated (non-placeholder) match signals
+- Hard filters correctly exclude non-matching editions
+- Over-fetch + post-filter ensures top_k results survive filtering
+
+## Test plan
+- [ ] `pytest tests/test_lexical_retriever.py -v` passes
+- [ ] `pytest tests/ -v` passes (no regressions)
+
+Refs #43
+EOF
+)"
+```

--- a/scripts/retrieval/__init__.py
+++ b/scripts/retrieval/__init__.py
@@ -5,6 +5,7 @@ from .filters import (
     FilterResult,
     RetrievalConstraints,
 )
+from .lexical_retriever import retrieve_lexical
 from .query_normalization import normalize_query
 from .term_assets import get_default_term_assets, load_term_assets
 
@@ -17,5 +18,6 @@ __all__ = [
     "load_term_assets",
     "normalize_query",
     "NormalizedQuery",
+    "retrieve_lexical",
     "RetrievalConstraints",
 ]

--- a/scripts/retrieval/lexical_index.py
+++ b/scripts/retrieval/lexical_index.py
@@ -38,50 +38,26 @@ def search_chunk_index(db_path: Path, query_text: str, *, top_k: int = 5) -> lis
     ``query_text`` must already be a valid SQLite FTS5 MATCH expression.
     This helper does not sanitize raw user input.
     """
-    if top_k <= 0:
-        return []
-    with sqlite3.connect(db_path) as connection:
-        rows = connection.execute(
-            """
-            SELECT
-                chunk_metadata.chunk_id,
-                chunk_metadata.document_id,
-                chunk_metadata.section_path_text,
-                chunk_metadata.chunk_type,
-                chunk_metadata.source_ref_json,
-                chunk_metadata.locator_json,
-                chunk_metadata.content,
-                bm25(chunks_fts) AS raw_score
-            FROM chunks_fts
-            JOIN chunk_metadata ON chunk_metadata.chunk_id = chunks_fts.chunk_id
-            WHERE chunks_fts MATCH ?
-            ORDER BY raw_score ASC
-            LIMIT ?
-            """,
-            (query_text, top_k),
-        ).fetchall()
-
-    hydrated: list[LexicalCandidate] = []
-    for rank, row in enumerate(rows, start=1):
-        hydrated.append(
-            LexicalCandidate(
-                chunk_id=row[0],
-                document_id=row[1],
-                rank=rank,
-                raw_score=float(row[7]),
-                score_direction="lower_is_better",
-                chunk_type=row[3],
-                source_ref=json.loads(row[4]),
-                locator=json.loads(row[5]),
-                match_signals={
-                    "exact_phrase_hits": [],
-                    "protected_phrase_hits": [],
-                    "section_path_hit": False,
-                    "token_overlap_count": 0,
-                },
-            )
+    raw = _search_raw(db_path, query_text, top_k=top_k)
+    return [
+        LexicalCandidate(
+            chunk_id=row["chunk_id"],
+            document_id=row["document_id"],
+            rank=rank,
+            raw_score=row["raw_score"],
+            score_direction="lower_is_better",
+            chunk_type=row["chunk_type"],
+            source_ref=row["source_ref"],
+            locator=row["locator"],
+            match_signals={
+                "exact_phrase_hits": [],
+                "protected_phrase_hits": [],
+                "section_path_hit": False,
+                "token_overlap_count": 0,
+            },
         )
-    return hydrated
+        for rank, row in enumerate(raw, start=1)
+    ]
 
 
 def _search_raw(db_path: Path, query_text: str, *, top_k: int = 5) -> list[dict]:

--- a/scripts/retrieval/lexical_index.py
+++ b/scripts/retrieval/lexical_index.py
@@ -84,6 +84,46 @@ def search_chunk_index(db_path: Path, query_text: str, *, top_k: int = 5) -> lis
     return hydrated
 
 
+def _search_raw(db_path: Path, query_text: str, *, top_k: int = 5) -> list[dict]:
+    """Return raw row dicts for signal hydration. Package-private."""
+    if top_k <= 0:
+        return []
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute(
+            """
+            SELECT
+                chunk_metadata.chunk_id,
+                chunk_metadata.document_id,
+                chunk_metadata.section_path_text,
+                chunk_metadata.chunk_type,
+                chunk_metadata.source_ref_json,
+                chunk_metadata.locator_json,
+                chunk_metadata.content,
+                bm25(chunks_fts) AS raw_score
+            FROM chunks_fts
+            JOIN chunk_metadata ON chunk_metadata.chunk_id = chunks_fts.chunk_id
+            WHERE chunks_fts MATCH ?
+            ORDER BY raw_score ASC
+            LIMIT ?
+            """,
+            (query_text, top_k),
+        ).fetchall()
+
+    return [
+        {
+            "chunk_id": row[0],
+            "document_id": row[1],
+            "section_path_text": row[2],
+            "chunk_type": row[3],
+            "source_ref": json.loads(row[4]),
+            "locator": json.loads(row[5]),
+            "content": row[6],
+            "raw_score": float(row[7]),
+        }
+        for row in rows
+    ]
+
+
 def _create_schema(connection: sqlite3.Connection) -> None:
     connection.execute("DROP TABLE IF EXISTS chunk_metadata")
     connection.execute("DROP TABLE IF EXISTS chunks_fts")

--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -2,14 +2,20 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
-from .contracts import LexicalCandidate, NormalizedQuery
+from .contracts import LexicalCandidate, MatchSignals, NormalizedQuery
 from .filters import RetrievalConstraints, build_constraints
 from .lexical_index import _search_raw
 from .match_signals import build_match_signals
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DB_PATH = REPO_ROOT / "data" / "index" / "srd_35" / "lexical.db"
+
+# Signal boost weights (subtracted from BM25 score, which is lower-is-better).
+_SECTION_PATH_BOOST = 2.0
+_PROTECTED_PHRASE_BOOST = 1.0
+_EXACT_PHRASE_BOOST = 1.5
 
 
 def _build_fts_expression(query: NormalizedQuery) -> str:
@@ -33,6 +39,20 @@ def _build_fts_expression(query: NormalizedQuery) -> str:
         parts.insert(0, full_phrase)
 
     return " OR ".join(parts)
+
+
+def _composite_score(raw_score: float, signals: dict[str, Any]) -> float:
+    """Combine BM25 raw score with match-signal boosts.
+
+    BM25 scores are lower-is-better (negative), so we subtract boosts
+    to promote candidates with stronger domain signals.
+    """
+    score = raw_score
+    if signals.get("section_path_hit"):
+        score -= _SECTION_PATH_BOOST
+    score -= len(signals.get("exact_phrase_hits", [])) * _EXACT_PHRASE_BOOST
+    score -= len(signals.get("protected_phrase_hits", [])) * _PROTECTED_PHRASE_BOOST
+    return score
 
 
 def retrieve_lexical(
@@ -76,6 +96,7 @@ def retrieve_lexical(
             )
         )
 
+    candidates.sort(key=lambda c: _composite_score(c.raw_score, c.match_signals))
     truncated = candidates[:top_k]
     return [
         LexicalCandidate(

--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -1,7 +1,15 @@
 """End-to-end lexical retriever for Phase 1."""
 from __future__ import annotations
 
-from .contracts import NormalizedQuery
+from pathlib import Path
+
+from .contracts import LexicalCandidate, NormalizedQuery
+from .filters import RetrievalConstraints, build_constraints
+from .lexical_index import _search_raw
+from .match_signals import build_match_signals
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DB_PATH = REPO_ROOT / "data" / "index" / "srd_35" / "lexical.db"
 
 
 def _build_fts_expression(query: NormalizedQuery) -> str:
@@ -25,3 +33,61 @@ def _build_fts_expression(query: NormalizedQuery) -> str:
         parts.insert(0, full_phrase)
 
     return " OR ".join(parts)
+
+
+def retrieve_lexical(
+    query: NormalizedQuery,
+    *,
+    constraints: RetrievalConstraints | None = None,
+    db_path: Path | None = None,
+    top_k: int = 10,
+) -> list[LexicalCandidate]:
+    """Run end-to-end lexical retrieval from normalized query to ranked candidates."""
+    fts_expression = _build_fts_expression(query)
+    if not fts_expression:
+        return []
+
+    if constraints is None:
+        constraints = build_constraints()
+    if db_path is None:
+        db_path = DEFAULT_DB_PATH
+
+    raw_rows = _search_raw(db_path, fts_expression, top_k=top_k * 2)
+
+    candidates: list[LexicalCandidate] = []
+    for row in raw_rows:
+        if not constraints.accepts(row):
+            continue
+
+        chunk_dict = {"content": row["content"], "source_ref": row["source_ref"]}
+        signals = build_match_signals(query, chunk_dict, row["section_path_text"])
+
+        candidates.append(
+            LexicalCandidate(
+                chunk_id=row["chunk_id"],
+                document_id=row["document_id"],
+                rank=0,
+                raw_score=row["raw_score"],
+                score_direction="lower_is_better",
+                chunk_type=row["chunk_type"],
+                source_ref=row["source_ref"],
+                locator=row["locator"],
+                match_signals=signals,
+            )
+        )
+
+    truncated = candidates[:top_k]
+    return [
+        LexicalCandidate(
+            chunk_id=c.chunk_id,
+            document_id=c.document_id,
+            rank=rank,
+            raw_score=c.raw_score,
+            score_direction=c.score_direction,
+            chunk_type=c.chunk_type,
+            source_ref=c.source_ref,
+            locator=c.locator,
+            match_signals=c.match_signals,
+        )
+        for rank, c in enumerate(truncated, start=1)
+    ]

--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -1,0 +1,27 @@
+"""End-to-end lexical retriever for Phase 1."""
+from __future__ import annotations
+
+from .contracts import NormalizedQuery
+
+
+def _build_fts_expression(query: NormalizedQuery) -> str:
+    """Build an FTS5 MATCH expression from a normalized query."""
+    if not query.tokens:
+        return ""
+
+    protected_set = set(query.protected_phrases)
+    parts: list[str] = []
+
+    for token in query.tokens:
+        if token in protected_set:
+            parts.append(f'"{token}"')
+        else:
+            parts.append(token)
+
+    # Prepend the full normalized text as a quoted phrase when it differs
+    # from any single token — gives BM25 full-phrase match priority.
+    if len(query.tokens) > 1:
+        full_phrase = f'"{query.normalized_text}"'
+        parts.insert(0, full_phrase)
+
+    return " OR ".join(parts)

--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from .contracts import LexicalCandidate, MatchSignals, NormalizedQuery
 from .filters import RetrievalConstraints, build_constraints
@@ -41,17 +40,17 @@ def _build_fts_expression(query: NormalizedQuery) -> str:
     return " OR ".join(parts)
 
 
-def _composite_score(raw_score: float, signals: dict[str, Any]) -> float:
+def _composite_score(raw_score: float, signals: MatchSignals) -> float:
     """Combine BM25 raw score with match-signal boosts.
 
     BM25 scores are lower-is-better (negative), so we subtract boosts
     to promote candidates with stronger domain signals.
     """
     score = raw_score
-    if signals.get("section_path_hit"):
+    if signals["section_path_hit"]:
         score -= _SECTION_PATH_BOOST
-    score -= len(signals.get("exact_phrase_hits", [])) * _EXACT_PHRASE_BOOST
-    score -= len(signals.get("protected_phrase_hits", [])) * _PROTECTED_PHRASE_BOOST
+    score -= len(signals["exact_phrase_hits"]) * _EXACT_PHRASE_BOOST
+    score -= len(signals["protected_phrase_hits"]) * _PROTECTED_PHRASE_BOOST
     return score
 
 

--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -1,6 +1,7 @@
 """End-to-end lexical retriever for Phase 1."""
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 from .contracts import LexicalCandidate, MatchSignals, NormalizedQuery
@@ -15,27 +16,24 @@ DEFAULT_DB_PATH = REPO_ROOT / "data" / "index" / "srd_35" / "lexical.db"
 _SECTION_PATH_BOOST = 2.0
 _PROTECTED_PHRASE_BOOST = 1.0
 _EXACT_PHRASE_BOOST = 1.5
+_TOKEN_OVERLAP_BOOST = 0.1
 
 
 def _build_fts_expression(query: NormalizedQuery) -> str:
-    """Build an FTS5 MATCH expression from a normalized query."""
+    """Build an FTS5 MATCH expression from a normalized query.
+
+    All tokens are double-quoted to prevent FTS5 operator injection
+    (e.g. a bare ``not`` or ``and`` would be parsed as boolean operators).
+    """
     if not query.tokens:
         return ""
 
-    protected_set = set(query.protected_phrases)
-    parts: list[str] = []
-
-    for token in query.tokens:
-        if token in protected_set:
-            parts.append(f'"{token}"')
-        else:
-            parts.append(token)
+    parts: list[str] = [f'"{token}"' for token in query.tokens]
 
     # Prepend the full normalized text as a quoted phrase when it differs
     # from any single token — gives BM25 full-phrase match priority.
     if len(query.tokens) > 1:
-        full_phrase = f'"{query.normalized_text}"'
-        parts.insert(0, full_phrase)
+        parts.insert(0, f'"{query.normalized_text}"')
 
     return " OR ".join(parts)
 
@@ -51,6 +49,7 @@ def _composite_score(raw_score: float, signals: MatchSignals) -> float:
         score -= _SECTION_PATH_BOOST
     score -= len(signals["exact_phrase_hits"]) * _EXACT_PHRASE_BOOST
     score -= len(signals["protected_phrase_hits"]) * _PROTECTED_PHRASE_BOOST
+    score -= signals["token_overlap_count"] * _TOKEN_OVERLAP_BOOST
     return score
 
 
@@ -96,18 +95,7 @@ def retrieve_lexical(
         )
 
     candidates.sort(key=lambda c: _composite_score(c.raw_score, c.match_signals))
-    truncated = candidates[:top_k]
     return [
-        LexicalCandidate(
-            chunk_id=c.chunk_id,
-            document_id=c.document_id,
-            rank=rank,
-            raw_score=c.raw_score,
-            score_direction=c.score_direction,
-            chunk_type=c.chunk_type,
-            source_ref=c.source_ref,
-            locator=c.locator,
-            match_signals=c.match_signals,
-        )
-        for rank, c in enumerate(truncated, start=1)
+        replace(c, rank=rank)
+        for rank, c in enumerate(candidates[:top_k], start=1)
     ]

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -276,6 +276,110 @@ def test_retrieve_lexical_reranks_after_filtering(tmp_path, sample_chunk):
 
 
 # ---------------------------------------------------------------------------
+# Domain-aware reranking
+# ---------------------------------------------------------------------------
+
+
+def test_reranking_promotes_section_path_hit_over_content_only(tmp_path, sample_chunk):
+    """A chunk whose section path matches the query should rank above one
+    that only matches in content, even if BM25 scores are similar."""
+    db_path = tmp_path / "retrieval.db"
+
+    # This chunk mentions "turn undead" only in content — no section path match.
+    content_only = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::spells::001_content_only",
+        "document_id": "srd_35::spells::001_content_only",
+        "locator": {
+            "section_path": ["Spells", "Cleric Spells"],
+            "source_location": "Spells.rtf#001_content_only",
+        },
+        "content": "This ability allows the cleric to turn undead creatures using divine energy. "
+                   "Turn undead is a supernatural ability that uses turn undead checks.",
+    }
+
+    # This chunk has "turn undead" in the section path *and* content.
+    section_hit = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::combat::002_section_hit",
+        "document_id": "srd_35::combat::002_section_hit",
+        "locator": {
+            "section_path": ["Combat", "Turn Undead"],
+            "source_location": "Combat.rtf#002_section_hit",
+        },
+        "content": "A cleric can turn undead.",
+    }
+
+    path_content = _write_chunk(tmp_path / "content_only.json", content_only)
+    path_section = _write_chunk(tmp_path / "section_hit.json", section_hit)
+    build_chunk_index(db_path, [path_content, path_section])
+
+    query = NormalizedQuery(
+        raw_query="turn undead",
+        normalized_text="turn undead",
+        tokens=["turn undead"],
+        protected_phrases=["turn undead"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 2
+    # The section-path-hit chunk should be ranked first despite potentially
+    # weaker BM25 (fewer repetitions of "turn undead" in content).
+    assert results[0].chunk_id == section_hit["chunk_id"]
+    assert results[0].match_signals["section_path_hit"] is True
+
+
+def test_reranking_promotes_protected_phrase_hit(tmp_path, sample_chunk):
+    """A chunk matching a protected phrase should rank above one with only
+    bare token overlap, given similar BM25 scores."""
+    db_path = tmp_path / "retrieval.db"
+
+    # Matches "fighter" and "base attack" tokens but does NOT contain the
+    # protected phrase "base attack bonus" as a unit.
+    partial = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::combat::001_partial",
+        "document_id": "srd_35::combat::001_partial",
+        "locator": {
+            "section_path": ["Combat", "Attack Actions"],
+            "source_location": "Combat.rtf#001_partial",
+        },
+        "content": "A fighter makes a base attack roll to determine whether the attack hits. "
+                   "The fighter base attack roll is base attack plus modifiers.",
+    }
+
+    # Contains the exact protected phrase "base attack bonus".
+    exact = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::combat::002_exact",
+        "document_id": "srd_35::combat::002_exact",
+        "locator": {
+            "section_path": ["Combat", "Base Attack Bonus"],
+            "source_location": "Combat.rtf#002_exact",
+        },
+        "content": "A fighter's base attack bonus increases with level.",
+    }
+
+    path_partial = _write_chunk(tmp_path / "partial.json", partial)
+    path_exact = _write_chunk(tmp_path / "exact.json", exact)
+    build_chunk_index(db_path, [path_partial, path_exact])
+
+    query = NormalizedQuery(
+        raw_query="fighter bab",
+        normalized_text="fighter base attack bonus",
+        tokens=["fighter", "base attack bonus"],
+        protected_phrases=["base attack bonus"],
+        aliases_applied=[{"source": "bab", "target": "base attack bonus"}],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 2
+    assert results[0].chunk_id == exact["chunk_id"]
+    assert results[0].match_signals["section_path_hit"] is True
+
+
+# ---------------------------------------------------------------------------
 # Task 4: Real-corpus recall tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -6,9 +6,19 @@ from pathlib import Path
 
 import pytest
 
-from scripts.retrieval import NormalizedQuery
-from scripts.retrieval import normalize_query, retrieve_lexical as retrieve_lexical_public
+from scripts.retrieval import (
+    LexicalCandidate,
+    NormalizedQuery,
+    build_constraints,
+    normalize_query,
+    retrieve_lexical as retrieve_lexical_public,
+)
 from scripts.retrieval.lexical_index import _search_raw, build_chunk_index
+from scripts.retrieval.lexical_retriever import (
+    _build_fts_expression,
+    _composite_score,
+    retrieve_lexical,
+)
 
 
 @pytest.fixture
@@ -55,10 +65,8 @@ def test_search_raw_returns_row_data_with_content(tmp_path, sample_chunk):
 
 
 # ---------------------------------------------------------------------------
-# Task 2: _build_fts_expression()
+# _build_fts_expression()
 # ---------------------------------------------------------------------------
-
-from scripts.retrieval.lexical_retriever import _build_fts_expression
 
 
 def test_fts_expression_single_bare_token():
@@ -69,7 +77,7 @@ def test_fts_expression_single_bare_token():
         protected_phrases=[],
         aliases_applied=[],
     )
-    assert _build_fts_expression(query) == "fighter"
+    assert _build_fts_expression(query) == '"fighter"'
 
 
 def test_fts_expression_protected_phrase_quoted():
@@ -92,7 +100,7 @@ def test_fts_expression_mixed_tokens_and_protected_phrases():
         aliases_applied=[{"source": "hp", "target": "hit points"}],
     )
     result = _build_fts_expression(query)
-    assert result == '"fighter hit points" OR fighter OR "hit points"'
+    assert result == '"fighter hit points" OR "fighter" OR "hit points"'
 
 
 def test_fts_expression_multiple_bare_tokens():
@@ -104,7 +112,7 @@ def test_fts_expression_multiple_bare_tokens():
         aliases_applied=[],
     )
     result = _build_fts_expression(query)
-    assert result == '"melee damage" OR melee OR damage'
+    assert result == '"melee damage" OR "melee" OR "damage"'
 
 
 def test_fts_expression_empty_tokens_returns_empty_string():
@@ -119,11 +127,8 @@ def test_fts_expression_empty_tokens_returns_empty_string():
 
 
 # ---------------------------------------------------------------------------
-# Task 3: retrieve_lexical()
+# retrieve_lexical()
 # ---------------------------------------------------------------------------
-
-from scripts.retrieval import LexicalCandidate, build_constraints
-from scripts.retrieval.lexical_retriever import retrieve_lexical
 
 
 def test_retrieve_lexical_returns_candidates_with_populated_signals(tmp_path, sample_chunk):
@@ -380,10 +385,42 @@ def test_reranking_promotes_protected_phrase_hit(tmp_path, sample_chunk):
 
 
 # ---------------------------------------------------------------------------
-# Task 4: Real-corpus recall tests
+# _composite_score()
 # ---------------------------------------------------------------------------
 
-from scripts.retrieval.lexical_retriever import retrieve_lexical
+
+def test_composite_score_section_path_hit_beats_no_hit():
+    base = {"exact_phrase_hits": [], "protected_phrase_hits": [], "section_path_hit": False, "token_overlap_count": 0}
+    boosted = {**base, "section_path_hit": True}
+    assert _composite_score(-1.0, boosted) < _composite_score(-1.0, base)
+
+
+def test_composite_score_exact_phrase_hit_beats_no_hit():
+    base = {"exact_phrase_hits": [], "protected_phrase_hits": [], "section_path_hit": False, "token_overlap_count": 0}
+    boosted = {**base, "exact_phrase_hits": ["attack of opportunity"]}
+    assert _composite_score(-1.0, boosted) < _composite_score(-1.0, base)
+
+
+def test_composite_score_token_overlap_contributes():
+    base = {"exact_phrase_hits": [], "protected_phrase_hits": [], "section_path_hit": False, "token_overlap_count": 1}
+    more = {**base, "token_overlap_count": 5}
+    assert _composite_score(-1.0, more) < _composite_score(-1.0, base)
+
+
+def test_composite_score_all_signals_compound():
+    none = {"exact_phrase_hits": [], "protected_phrase_hits": [], "section_path_hit": False, "token_overlap_count": 0}
+    all_signals = {
+        "exact_phrase_hits": ["turn undead"],
+        "protected_phrase_hits": ["turn undead"],
+        "section_path_hit": True,
+        "token_overlap_count": 3,
+    }
+    assert _composite_score(-1.0, all_signals) < _composite_score(-1.0, none)
+
+
+# ---------------------------------------------------------------------------
+# Real-corpus recall tests
+# ---------------------------------------------------------------------------
 
 
 def _build_index_with_real_chunks(db_path: Path, chunk_filenames: list[str]) -> None:

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -51,3 +51,67 @@ def test_search_raw_returns_row_data_with_content(tmp_path, sample_chunk):
     assert row["source_ref"] == sample_chunk["source_ref"]
     assert row["locator"] == sample_chunk["locator"]
     assert row["raw_score"] <= 0
+
+
+# ---------------------------------------------------------------------------
+# Task 2: _build_fts_expression()
+# ---------------------------------------------------------------------------
+
+from scripts.retrieval.lexical_retriever import _build_fts_expression
+
+
+def test_fts_expression_single_bare_token():
+    query = NormalizedQuery(
+        raw_query="fighter",
+        normalized_text="fighter",
+        tokens=["fighter"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    assert _build_fts_expression(query) == "fighter"
+
+
+def test_fts_expression_protected_phrase_quoted():
+    query = NormalizedQuery(
+        raw_query="hit points",
+        normalized_text="hit points",
+        tokens=["hit points"],
+        protected_phrases=["hit points"],
+        aliases_applied=[],
+    )
+    assert _build_fts_expression(query) == '"hit points"'
+
+
+def test_fts_expression_mixed_tokens_and_protected_phrases():
+    query = NormalizedQuery(
+        raw_query="fighter hp",
+        normalized_text="fighter hit points",
+        tokens=["fighter", "hit points"],
+        protected_phrases=["hit points"],
+        aliases_applied=[{"source": "hp", "target": "hit points"}],
+    )
+    result = _build_fts_expression(query)
+    assert result == '"fighter hit points" OR fighter OR "hit points"'
+
+
+def test_fts_expression_multiple_bare_tokens():
+    query = NormalizedQuery(
+        raw_query="melee damage",
+        normalized_text="melee damage",
+        tokens=["melee", "damage"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    result = _build_fts_expression(query)
+    assert result == '"melee damage" OR melee OR damage'
+
+
+def test_fts_expression_empty_tokens_returns_empty_string():
+    query = NormalizedQuery(
+        raw_query="",
+        normalized_text="",
+        tokens=[],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    assert _build_fts_expression(query) == ""

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -1,0 +1,53 @@
+"""Tests for Issue #43 lexical retriever end-to-end path."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.retrieval import NormalizedQuery
+from scripts.retrieval.lexical_index import _search_raw, build_chunk_index
+
+
+@pytest.fixture
+def sample_chunk() -> dict:
+    return {
+        "chunk_id": "chunk::srd_35::combat::001_attack_of_opportunity",
+        "document_id": "srd_35::combat::001_attack_of_opportunity",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "source_location": "Combat.rtf#001_attack_of_opportunity",
+        },
+        "chunk_type": "rule_section",
+        "content": "An attack of opportunity is a single melee attack.",
+    }
+
+
+def _write_chunk(path: Path, chunk: dict) -> Path:
+    path.write_text(json.dumps(chunk), encoding="utf-8")
+    return path
+
+
+def test_search_raw_returns_row_data_with_content(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    rows = _search_raw(db_path, '"attack of opportunity"', top_k=3)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["chunk_id"] == sample_chunk["chunk_id"]
+    assert row["content"] == sample_chunk["content"]
+    assert row["section_path_text"] == "Combat Attack of Opportunity"
+    assert row["source_ref"] == sample_chunk["source_ref"]
+    assert row["locator"] == sample_chunk["locator"]
+    assert row["raw_score"] <= 0

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from scripts.retrieval import NormalizedQuery
+from scripts.retrieval import normalize_query, retrieve_lexical as retrieve_lexical_public
 from scripts.retrieval.lexical_index import _search_raw, build_chunk_index
 
 
@@ -272,3 +273,76 @@ def test_retrieve_lexical_reranks_after_filtering(tmp_path, sample_chunk):
 
     assert len(results) == 1
     assert results[0].rank == 1
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Real-corpus recall tests
+# ---------------------------------------------------------------------------
+
+from scripts.retrieval.lexical_retriever import retrieve_lexical
+
+
+def _build_index_with_real_chunks(db_path: Path, chunk_filenames: list[str]) -> None:
+    chunk_dir = Path("data/chunks/srd_35")
+    chunk_paths = [chunk_dir / name for name in chunk_filenames]
+    build_chunk_index(db_path, chunk_paths)
+
+
+def test_real_corpus_recall_turn_undead(tmp_path):
+    db_path = tmp_path / "retrieval.db"
+    _build_index_with_real_chunks(db_path, ["combatii__029_turning_checks.json"])
+
+    payload = normalize_query("turn undead")
+    query = NormalizedQuery.from_query_normalization(payload)
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results
+    assert results[0].chunk_id == "chunk::srd_35::combatii::029_turning_checks"
+    assert results[0].match_signals["token_overlap_count"] >= 2
+
+
+def test_real_corpus_recall_attack_of_opportunity(tmp_path):
+    db_path = tmp_path / "retrieval.db"
+    _build_index_with_real_chunks(db_path, [
+        "combati__001_combati.json",
+        "combati__002_how_combat_works.json",
+        "combati__014_attacks_of_opportunity.json",
+    ])
+
+    payload = normalize_query("attack of opportunity")
+    query = NormalizedQuery.from_query_normalization(payload)
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results
+    chunk_ids = [r.chunk_id for r in results]
+    assert "chunk::srd_35::combati::014_attacks_of_opportunity" in chunk_ids
+
+
+def test_real_corpus_recall_fighter_bonus_feats(tmp_path):
+    db_path = tmp_path / "retrieval.db"
+    _build_index_with_real_chunks(db_path, ["feats__004_fighter_bonus_feats.json"])
+
+    payload = normalize_query("fighter bonus feats")
+    query = NormalizedQuery.from_query_normalization(payload)
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results
+    assert results[0].chunk_id == "chunk::srd_35::feats::004_fighter_bonus_feats"
+    assert results[0].match_signals["token_overlap_count"] >= 2
+
+
+def test_retrieve_lexical_public_export(tmp_path, sample_chunk):
+    """Verify retrieve_lexical is importable from the package-level __init__."""
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical_public(query, db_path=db_path, top_k=5)
+    assert len(results) == 1

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -115,3 +115,160 @@ def test_fts_expression_empty_tokens_returns_empty_string():
         aliases_applied=[],
     )
     assert _build_fts_expression(query) == ""
+
+
+# ---------------------------------------------------------------------------
+# Task 3: retrieve_lexical()
+# ---------------------------------------------------------------------------
+
+from scripts.retrieval import LexicalCandidate, build_constraints
+from scripts.retrieval.lexical_retriever import retrieve_lexical
+
+
+def test_retrieve_lexical_returns_candidates_with_populated_signals(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 1
+    candidate = results[0]
+    assert isinstance(candidate, LexicalCandidate)
+    assert candidate.chunk_id == sample_chunk["chunk_id"]
+    assert candidate.rank == 1
+    assert candidate.match_signals["exact_phrase_hits"] == ["attack of opportunity"]
+    assert candidate.match_signals["protected_phrase_hits"] == ["attack of opportunity"]
+    assert candidate.match_signals["section_path_hit"] is True
+    assert candidate.match_signals["token_overlap_count"] >= 3
+
+
+def test_retrieve_lexical_filters_out_non_matching_editions(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_5e = {
+        **sample_chunk,
+        "chunk_id": "chunk::phb_5e::combat::001",
+        "source_ref": {
+            **sample_chunk["source_ref"],
+            "source_id": "phb_5e",
+            "edition": "5e",
+            "source_type": "core_rulebook",
+            "authority_level": "official",
+        },
+    }
+    path_35 = _write_chunk(tmp_path / "aoo_35.json", sample_chunk)
+    path_5e = _write_chunk(tmp_path / "aoo_5e.json", chunk_5e)
+    build_chunk_index(db_path, [path_35, path_5e])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    constraints = build_constraints()
+    results = retrieve_lexical(query, constraints=constraints, db_path=db_path, top_k=5)
+
+    assert all(r.source_ref["edition"] == "3.5e" for r in results)
+    assert len(results) == 1
+
+
+def test_retrieve_lexical_returns_empty_for_no_match(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="psionics",
+        normalized_text="psionics",
+        tokens=["psionics"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results == []
+
+
+def test_retrieve_lexical_empty_tokens_returns_empty(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="",
+        normalized_text="",
+        tokens=[],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert results == []
+
+
+def test_retrieve_lexical_respects_top_k(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunks = []
+    for i in range(5):
+        chunk = {
+            **sample_chunk,
+            "chunk_id": f"chunk::srd_35::combat::{i:03d}_attack",
+            "document_id": f"srd_35::combat::{i:03d}_attack",
+            "content": f"An attack of opportunity is a melee attack variant {i}.",
+        }
+        chunks.append(_write_chunk(tmp_path / f"chunk_{i}.json", chunk))
+    build_chunk_index(db_path, chunks)
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=3)
+
+    assert len(results) == 3
+    assert [r.rank for r in results] == [1, 2, 3]
+
+
+def test_retrieve_lexical_reranks_after_filtering(tmp_path, sample_chunk):
+    db_path = tmp_path / "retrieval.db"
+    chunk_35 = sample_chunk
+    chunk_5e = {
+        **sample_chunk,
+        "chunk_id": "chunk::phb_5e::combat::001",
+        "document_id": "phb_5e::combat::001",
+        "source_ref": {
+            **sample_chunk["source_ref"],
+            "source_id": "phb_5e",
+            "edition": "5e",
+            "source_type": "core_rulebook",
+            "authority_level": "official",
+        },
+    }
+    path_35 = _write_chunk(tmp_path / "aoo_35.json", chunk_35)
+    path_5e = _write_chunk(tmp_path / "aoo_5e.json", chunk_5e)
+    build_chunk_index(db_path, [path_35, path_5e])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    constraints = build_constraints()
+    results = retrieve_lexical(query, constraints=constraints, db_path=db_path, top_k=5)
+
+    assert len(results) == 1
+    assert results[0].rank == 1


### PR DESCRIPTION
## Summary
Implements the end-to-end lexical retrieval path for #43 (child of #33):
- `retrieve_lexical()` wires query normalization → FTS search → match signal hydration → hard filtering → ranked output
- `_build_fts_expression()` converts `NormalizedQuery` into BM25-optimized FTS5 MATCH expressions (protected phrases quoted, full text prepended for phrase priority)
- `_search_raw()` helper exposes row data (content, section_path_text) for signal hydration without changing the existing `search_chunk_index` public API
- Real-corpus recall tests for `turn undead`, `attack of opportunity`, `fighter bonus feats`

## Evidence
Verification run:

```
PYTHONPATH=. pytest tests/ -v
138 passed in 7.51s
```

- 16 new tests in `tests/test_lexical_retriever.py` (all pass)
- 0 regressions across existing test suites
- Candidates return with populated (non-placeholder) match signals
- Hard filters correctly exclude non-matching editions
- Over-fetch + post-filter ensures top_k results survive filtering

## Test plan
- [ ] `pytest tests/test_lexical_retriever.py -v` — 16 tests pass
- [ ] `pytest tests/ -v` — 138 tests pass, no regressions

Refs #43