### PR TITLE
feat(retrieval): add chunk-type prior to lexical scoring

### DIFF
--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -19,21 +19,39 @@ _EXACT_PHRASE_BOOST = 1.5
 _TOKEN_OVERLAP_BOOST = 0.1
 
 # Chunk-type prior: rule-bearing types get a boost, generic/unknown get none.
+# Keys must match the chunk_type enum in schemas/chunk.schema.json — a guard
+# test in test_lexical_retriever.py enforces this at CI time.
+#
+# Ordering rationale:
+#   rule_section (1.0) — top-level rule definitions, highest signal for rule lookups
+#   class_feature (0.8) — named mechanical features, almost always what a
+#       class-related query wants; ranked above individual entries because they
+#       carry more context per chunk
+#   feat/skill/spell/condition_entry (0.6) — discrete catalogue entries
+#   subsection (0.5) — general rule prose, common but less targeted
+#   errata_note (0.4) — authoritative corrections
+#   table, faq_note, glossary_entry (0.3) — supporting reference material
+#   paragraph_group (0.2) — contextual prose groupings
+#   example, sidebar (0.1) — illustrative, rarely the primary answer
+#   generic (0.0) — no signal (e.g. legal/license boilerplate)
+#
+# Most types beyond rule_section/subsection/generic are forward-looking; the
+# current Phase 1 classifier mostly emits those three.
 _CHUNK_TYPE_PRIOR: dict[str, float] = {
     "rule_section": 1.0,
-    "subsection": 0.5,
     "class_feature": 0.8,
     "feat_entry": 0.6,
     "skill_entry": 0.6,
     "spell_entry": 0.6,
     "condition_entry": 0.6,
-    "table": 0.3,
-    "example": 0.1,
-    "sidebar": 0.1,
+    "subsection": 0.5,
     "errata_note": 0.4,
+    "table": 0.3,
     "faq_note": 0.3,
     "glossary_entry": 0.3,
     "paragraph_group": 0.2,
+    "example": 0.1,
+    "sidebar": 0.1,
     "generic": 0.0,
 }
 

--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -18,6 +18,25 @@ _PROTECTED_PHRASE_BOOST = 1.0
 _EXACT_PHRASE_BOOST = 1.5
 _TOKEN_OVERLAP_BOOST = 0.1
 
+# Chunk-type prior: rule-bearing types get a boost, generic/unknown get none.
+_CHUNK_TYPE_PRIOR: dict[str, float] = {
+    "rule_section": 1.0,
+    "subsection": 0.5,
+    "class_feature": 0.8,
+    "feat_entry": 0.6,
+    "skill_entry": 0.6,
+    "spell_entry": 0.6,
+    "condition_entry": 0.6,
+    "table": 0.3,
+    "example": 0.1,
+    "sidebar": 0.1,
+    "errata_note": 0.4,
+    "faq_note": 0.3,
+    "glossary_entry": 0.3,
+    "paragraph_group": 0.2,
+    "generic": 0.0,
+}
+
 
 def _build_fts_expression(query: NormalizedQuery) -> str:
     """Build an FTS5 MATCH expression from a normalized query.
@@ -38,7 +57,9 @@ def _build_fts_expression(query: NormalizedQuery) -> str:
     return " OR ".join(parts)
 
 
-def _composite_score(raw_score: float, signals: MatchSignals) -> float:
+def _composite_score(
+    raw_score: float, signals: MatchSignals, chunk_type: str = ""
+) -> float:
     """Combine BM25 raw score with match-signal boosts.
 
     BM25 scores are lower-is-better (negative), so we subtract boosts
@@ -50,6 +71,7 @@ def _composite_score(raw_score: float, signals: MatchSignals) -> float:
     score -= len(signals["exact_phrase_hits"]) * _EXACT_PHRASE_BOOST
     score -= len(signals["protected_phrase_hits"]) * _PROTECTED_PHRASE_BOOST
     score -= signals["token_overlap_count"] * _TOKEN_OVERLAP_BOOST
+    score -= _CHUNK_TYPE_PRIOR.get(chunk_type, 0.0)
     return score
 
 
@@ -94,7 +116,9 @@ def retrieve_lexical(
             )
         )
 
-    candidates.sort(key=lambda c: _composite_score(c.raw_score, c.match_signals))
+    candidates.sort(
+        key=lambda c: _composite_score(c.raw_score, c.match_signals, c.chunk_type)
+    )
     return [
         replace(c, rank=rank)
         for rank, c in enumerate(candidates[:top_k], start=1)

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -15,10 +15,30 @@ from scripts.retrieval import (
 )
 from scripts.retrieval.lexical_index import _search_raw, build_chunk_index
 from scripts.retrieval.lexical_retriever import (
+    _CHUNK_TYPE_PRIOR,
     _build_fts_expression,
     _composite_score,
     retrieve_lexical,
 )
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schemas" / "chunk.schema.json"
+
+
+# ---------------------------------------------------------------------------
+# Schema / classifier drift guard
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_type_prior_keys_match_schema_enum():
+    """Guard: _CHUNK_TYPE_PRIOR keys must stay in sync with chunk.schema.json."""
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    schema_enum = set(schema["properties"]["chunk_type"]["enum"])
+    prior_keys = set(_CHUNK_TYPE_PRIOR.keys())
+    assert prior_keys == schema_enum, (
+        f"Drift detected.\n"
+        f"  In schema but not in prior: {schema_enum - prior_keys}\n"
+        f"  In prior but not in schema: {prior_keys - schema_enum}"
+    )
 
 
 @pytest.fixture

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -335,6 +335,45 @@ def test_reranking_promotes_section_path_hit_over_content_only(tmp_path, sample_
     assert results[0].match_signals["section_path_hit"] is True
 
 
+def test_reranking_promotes_rule_section_over_generic(tmp_path, sample_chunk):
+    """A rule_section chunk should rank above a generic chunk with the same
+    content and BM25 score, due to the chunk-type prior."""
+    db_path = tmp_path / "retrieval.db"
+
+    generic_chunk = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::legal::001_generic",
+        "document_id": "srd_35::legal::001_generic",
+        "chunk_type": "generic",
+        "content": "An attack of opportunity is a single melee attack.",
+    }
+
+    rule_chunk = {
+        **sample_chunk,
+        "chunk_id": "chunk::srd_35::combat::001_rule",
+        "document_id": "srd_35::combat::001_rule",
+        "chunk_type": "rule_section",
+        "content": "An attack of opportunity is a single melee attack.",
+    }
+
+    path_generic = _write_chunk(tmp_path / "generic.json", generic_chunk)
+    path_rule = _write_chunk(tmp_path / "rule.json", rule_chunk)
+    build_chunk_index(db_path, [path_generic, path_rule])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 2
+    assert results[0].chunk_type == "rule_section"
+    assert results[1].chunk_type == "generic"
+
+
 def test_reranking_promotes_protected_phrase_hit(tmp_path, sample_chunk):
     """A chunk matching a protected phrase should rank above one with only
     bare token overlap, given similar BM25 scores."""
@@ -416,6 +455,21 @@ def test_composite_score_all_signals_compound():
         "token_overlap_count": 3,
     }
     assert _composite_score(-1.0, all_signals) < _composite_score(-1.0, none)
+
+
+def test_composite_score_chunk_type_prior_rule_section_beats_generic():
+    base = {"exact_phrase_hits": [], "protected_phrase_hits": [], "section_path_hit": False, "token_overlap_count": 0}
+    assert _composite_score(-1.0, base, "rule_section") < _composite_score(-1.0, base, "generic")
+
+
+def test_composite_score_chunk_type_prior_subsection_beats_generic():
+    base = {"exact_phrase_hits": [], "protected_phrase_hits": [], "section_path_hit": False, "token_overlap_count": 0}
+    assert _composite_score(-1.0, base, "subsection") < _composite_score(-1.0, base, "generic")
+
+
+def test_composite_score_chunk_type_prior_unknown_type_gets_no_boost():
+    base = {"exact_phrase_hits": [], "protected_phrase_hits": [], "section_path_hit": False, "token_overlap_count": 0}
+    assert _composite_score(-1.0, base, "unknown_type") == _composite_score(-1.0, base, "generic")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Wire `chunk_type` into `_composite_score()` as the last remaining domain-aware scoring signal from #47
- Define `_CHUNK_TYPE_PRIOR` mapping all 15 valid chunk types to numeric boosts (e.g. `rule_section: 1.0`, `generic: 0.0`)
- Rule-bearing chunk types now rank above generic/unknown types given similar BM25 scores

## Evidence
```
PYTHONPATH=. pytest tests/test_lexical_retriever.py -v
26 passed in 0.35s
```

```
PYTHONPATH=. pytest tests/ -v
152 passed in 6.69s
```

- 4 new tests: 3 unit tests for `_composite_score` chunk-type behavior + 1 integration test proving `rule_section` ranks above `generic`
- 0 regressions

## Test plan
- [ ] `pytest tests/test_lexical_retriever.py -v` — 26 tests pass
- [ ] `pytest tests/ -v` — full suite passes, no regressions

Refs #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)