### PR TITLE
feat(retrieval): candidate shaping by section root (#44)

### DIFF
--- a/scripts/retrieval/__init__.py
+++ b/scripts/retrieval/__init__.py
@@ -1,3 +1,4 @@
+from .candidate_shaping import CandidateGroup, shape_candidates
 from .contracts import LexicalCandidate, NormalizedQuery
 from .filters import (
     apply_filters,
@@ -12,6 +13,7 @@ from .term_assets import get_default_term_assets, load_term_assets
 __all__ = [
     "apply_filters",
     "build_constraints",
+    "CandidateGroup",
     "FilterResult",
     "get_default_term_assets",
     "LexicalCandidate",
@@ -20,4 +22,5 @@ __all__ = [
     "NormalizedQuery",
     "retrieve_lexical",
     "RetrievalConstraints",
+    "shape_candidates",
 ]

--- a/scripts/retrieval/candidate_shaping.py
+++ b/scripts/retrieval/candidate_shaping.py
@@ -1,9 +1,11 @@
 """Post-retrieval candidate shaping: group raw lexical hits by section.
 
 Sits between retrieve_lexical() and the future evidence pack / consolidation
-layer.  Groups candidates by their section root (first element of section_path
-from the locator) so downstream consumers can reason about coverage per source
-section rather than a flat ranked list.
+layer.  Groups candidates by (document_id, section_root) so downstream
+consumers can reason about coverage per source section rather than a flat
+ranked list.  Using a composite key prevents unrelated sections from
+different documents or sources from being merged just because they share
+a top-level heading name (e.g. two different sources both called "Combat").
 """
 from __future__ import annotations
 
@@ -14,8 +16,9 @@ from .contracts import LexicalCandidate
 
 @dataclass
 class CandidateGroup:
-    """A cluster of related candidates sharing a section root."""
+    """A cluster of related candidates sharing a document and section root."""
 
+    document_id: str
     section_root: str
     candidates: list[LexicalCandidate]
     best_rank: int
@@ -28,7 +31,7 @@ class CandidateGroup:
 def shape_candidates(
     candidates: list[LexicalCandidate],
 ) -> list[CandidateGroup]:
-    """Group ranked candidates by section root.
+    """Group ranked candidates by (document_id, section_root).
 
     Returns groups sorted by the best (lowest) rank in each group.
     Candidates within each group preserve their original rank order.
@@ -36,15 +39,16 @@ def shape_candidates(
     if not candidates:
         return []
 
-    groups_by_root: dict[str, list[LexicalCandidate]] = {}
+    groups: dict[tuple[str, str], list[LexicalCandidate]] = {}
     for candidate in candidates:
-        root = _section_root(candidate)
-        groups_by_root.setdefault(root, []).append(candidate)
+        key = _group_key(candidate)
+        groups.setdefault(key, []).append(candidate)
 
     result: list[CandidateGroup] = []
-    for root, members in groups_by_root.items():
+    for (doc_id, root), members in groups.items():
         members.sort(key=lambda c: c.rank)
         group = CandidateGroup(
+            document_id=doc_id,
             section_root=root,
             candidates=members,
             best_rank=members[0].rank,
@@ -55,9 +59,8 @@ def shape_candidates(
     return result
 
 
-def _section_root(candidate: LexicalCandidate) -> str:
-    """Extract the section root from a candidate's locator."""
+def _group_key(candidate: LexicalCandidate) -> tuple[str, str]:
+    """Composite group key: (document_id, section_root)."""
     section_path = candidate.locator.get("section_path") or []
-    if section_path:
-        return section_path[0]
-    return ""
+    root = section_path[0] if section_path else ""
+    return (candidate.document_id, root)

--- a/scripts/retrieval/candidate_shaping.py
+++ b/scripts/retrieval/candidate_shaping.py
@@ -1,0 +1,63 @@
+"""Post-retrieval candidate shaping: group raw lexical hits by section.
+
+Sits between retrieve_lexical() and the future evidence pack / consolidation
+layer.  Groups candidates by their section root (first element of section_path
+from the locator) so downstream consumers can reason about coverage per source
+section rather than a flat ranked list.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .contracts import LexicalCandidate
+
+
+@dataclass
+class CandidateGroup:
+    """A cluster of related candidates sharing a section root."""
+
+    section_root: str
+    candidates: list[LexicalCandidate]
+    best_rank: int = 0
+
+    @property
+    def size(self) -> int:
+        return len(self.candidates)
+
+
+def shape_candidates(
+    candidates: list[LexicalCandidate],
+) -> list[CandidateGroup]:
+    """Group ranked candidates by section root.
+
+    Returns groups sorted by the best (lowest) rank in each group.
+    Candidates within each group preserve their original rank order.
+    """
+    if not candidates:
+        return []
+
+    groups_by_root: dict[str, list[LexicalCandidate]] = {}
+    for candidate in candidates:
+        root = _section_root(candidate)
+        groups_by_root.setdefault(root, []).append(candidate)
+
+    result: list[CandidateGroup] = []
+    for root, members in groups_by_root.items():
+        members.sort(key=lambda c: c.rank)
+        group = CandidateGroup(
+            section_root=root,
+            candidates=members,
+            best_rank=members[0].rank,
+        )
+        result.append(group)
+
+    result.sort(key=lambda g: g.best_rank)
+    return result
+
+
+def _section_root(candidate: LexicalCandidate) -> str:
+    """Extract the section root from a candidate's locator."""
+    section_path = candidate.locator.get("section_path", [])
+    if section_path:
+        return section_path[0]
+    return ""

--- a/scripts/retrieval/candidate_shaping.py
+++ b/scripts/retrieval/candidate_shaping.py
@@ -18,7 +18,7 @@ class CandidateGroup:
 
     section_root: str
     candidates: list[LexicalCandidate]
-    best_rank: int = 0
+    best_rank: int
 
     @property
     def size(self) -> int:
@@ -57,7 +57,7 @@ def shape_candidates(
 
 def _section_root(candidate: LexicalCandidate) -> str:
     """Extract the section root from a candidate's locator."""
-    section_path = candidate.locator.get("section_path", [])
+    section_path = candidate.locator.get("section_path") or []
     if section_path:
         return section_path[0]
     return ""

--- a/tests/test_candidate_shaping.py
+++ b/tests/test_candidate_shaping.py
@@ -1,0 +1,129 @@
+"""Tests for candidate shaping (issue #44)."""
+from __future__ import annotations
+
+from scripts.retrieval.candidate_shaping import CandidateGroup, shape_candidates
+from scripts.retrieval.contracts import LexicalCandidate
+
+
+def _make_candidate(
+    chunk_id: str,
+    rank: int,
+    section_path: list[str],
+    *,
+    raw_score: float = -1.0,
+) -> LexicalCandidate:
+    return LexicalCandidate(
+        chunk_id=chunk_id,
+        document_id=chunk_id.replace("chunk::", ""),
+        rank=rank,
+        raw_score=raw_score,
+        score_direction="lower_is_better",
+        chunk_type="subsection",
+        source_ref={
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        locator={"section_path": section_path, "source_location": "test"},
+        match_signals={
+            "exact_phrase_hits": [],
+            "protected_phrase_hits": [],
+            "section_path_hit": False,
+            "token_overlap_count": 0,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Basic grouping
+# ---------------------------------------------------------------------------
+
+
+def test_shape_empty_returns_empty():
+    assert shape_candidates([]) == []
+
+
+def test_shape_single_candidate_returns_one_group():
+    c = _make_candidate("chunk::combat::001", rank=1, section_path=["Combat", "Initiative"])
+    groups = shape_candidates([c])
+
+    assert len(groups) == 1
+    assert groups[0].section_root == "Combat"
+    assert groups[0].candidates == [c]
+    assert groups[0].best_rank == 1
+    assert groups[0].size == 1
+
+
+def test_shape_groups_by_section_root():
+    c1 = _make_candidate("chunk::combat::001", rank=1, section_path=["Combat", "Initiative"])
+    c2 = _make_candidate("chunk::combat::002", rank=2, section_path=["Combat", "Attack of Opportunity"])
+    c3 = _make_candidate("chunk::spells::001", rank=3, section_path=["Spells", "Fireball"])
+
+    groups = shape_candidates([c1, c2, c3])
+
+    assert len(groups) == 2
+    assert groups[0].section_root == "Combat"
+    assert groups[0].size == 2
+    assert groups[1].section_root == "Spells"
+    assert groups[1].size == 1
+
+
+def test_shape_groups_sorted_by_best_rank():
+    c1 = _make_candidate("chunk::spells::001", rank=1, section_path=["Spells", "Fireball"])
+    c2 = _make_candidate("chunk::combat::001", rank=2, section_path=["Combat", "Initiative"])
+    c3 = _make_candidate("chunk::combat::002", rank=3, section_path=["Combat", "AoO"])
+
+    groups = shape_candidates([c1, c2, c3])
+
+    assert groups[0].section_root == "Spells"
+    assert groups[0].best_rank == 1
+    assert groups[1].section_root == "Combat"
+    assert groups[1].best_rank == 2
+
+
+def test_shape_preserves_rank_order_within_group():
+    c1 = _make_candidate("chunk::combat::003", rank=3, section_path=["Combat", "Damage"])
+    c2 = _make_candidate("chunk::combat::001", rank=1, section_path=["Combat", "Initiative"])
+    c3 = _make_candidate("chunk::combat::002", rank=2, section_path=["Combat", "AoO"])
+
+    groups = shape_candidates([c1, c2, c3])
+
+    assert len(groups) == 1
+    assert [c.rank for c in groups[0].candidates] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_shape_handles_empty_section_path():
+    c = _make_candidate("chunk::unknown::001", rank=1, section_path=[])
+    groups = shape_candidates([c])
+
+    assert len(groups) == 1
+    assert groups[0].section_root == ""
+
+
+def test_shape_handles_many_section_roots():
+    candidates = [
+        _make_candidate(f"chunk::s{i}::001", rank=i, section_path=[f"Section{i}", "Sub"])
+        for i in range(1, 6)
+    ]
+    groups = shape_candidates(candidates)
+
+    assert len(groups) == 5
+    assert [g.best_rank for g in groups] == [1, 2, 3, 4, 5]
+
+
+# ---------------------------------------------------------------------------
+# Public export
+# ---------------------------------------------------------------------------
+
+
+def test_shape_candidates_importable_from_package():
+    """Verify shape_candidates and CandidateGroup are importable from __init__."""
+    from scripts.retrieval import CandidateGroup as CG, shape_candidates as sc
+    assert sc is shape_candidates
+    assert CG is CandidateGroup

--- a/tests/test_candidate_shaping.py
+++ b/tests/test_candidate_shaping.py
@@ -10,17 +10,19 @@ def _make_candidate(
     rank: int,
     section_path: list[str],
     *,
+    document_id: str = "doc::srd_combat",
+    source_id: str = "srd_35",
     raw_score: float = -1.0,
 ) -> LexicalCandidate:
     return LexicalCandidate(
         chunk_id=chunk_id,
-        document_id=chunk_id.replace("chunk::", ""),
+        document_id=document_id,
         rank=rank,
         raw_score=raw_score,
         score_direction="lower_is_better",
         chunk_type="subsection",
         source_ref={
-            "source_id": "srd_35",
+            "source_id": source_id,
             "edition": "3.5e",
             "source_type": "srd",
             "authority_level": "official_reference",
@@ -45,20 +47,22 @@ def test_shape_empty_returns_empty():
 
 
 def test_shape_single_candidate_returns_one_group():
-    c = _make_candidate("chunk::combat::001", rank=1, section_path=["Combat", "Initiative"])
+    c = _make_candidate("chunk::001", rank=1, section_path=["Combat", "Initiative"])
     groups = shape_candidates([c])
 
     assert len(groups) == 1
+    assert groups[0].document_id == "doc::srd_combat"
     assert groups[0].section_root == "Combat"
     assert groups[0].candidates == [c]
     assert groups[0].best_rank == 1
     assert groups[0].size == 1
 
 
-def test_shape_groups_by_section_root():
-    c1 = _make_candidate("chunk::combat::001", rank=1, section_path=["Combat", "Initiative"])
-    c2 = _make_candidate("chunk::combat::002", rank=2, section_path=["Combat", "Attack of Opportunity"])
-    c3 = _make_candidate("chunk::spells::001", rank=3, section_path=["Spells", "Fireball"])
+def test_shape_groups_by_document_and_section_root():
+    """Same document, different section roots → separate groups."""
+    c1 = _make_candidate("chunk::001", rank=1, section_path=["Combat", "Initiative"])
+    c2 = _make_candidate("chunk::002", rank=2, section_path=["Combat", "AoO"])
+    c3 = _make_candidate("chunk::003", rank=3, section_path=["Spells", "Fireball"])
 
     groups = shape_candidates([c1, c2, c3])
 
@@ -70,9 +74,9 @@ def test_shape_groups_by_section_root():
 
 
 def test_shape_groups_sorted_by_best_rank():
-    c1 = _make_candidate("chunk::spells::001", rank=1, section_path=["Spells", "Fireball"])
-    c2 = _make_candidate("chunk::combat::001", rank=2, section_path=["Combat", "Initiative"])
-    c3 = _make_candidate("chunk::combat::002", rank=3, section_path=["Combat", "AoO"])
+    c1 = _make_candidate("chunk::001", rank=1, section_path=["Spells", "Fireball"])
+    c2 = _make_candidate("chunk::002", rank=2, section_path=["Combat", "Initiative"])
+    c3 = _make_candidate("chunk::003", rank=3, section_path=["Combat", "AoO"])
 
     groups = shape_candidates([c1, c2, c3])
 
@@ -83,9 +87,9 @@ def test_shape_groups_sorted_by_best_rank():
 
 
 def test_shape_preserves_rank_order_within_group():
-    c1 = _make_candidate("chunk::combat::003", rank=3, section_path=["Combat", "Damage"])
-    c2 = _make_candidate("chunk::combat::001", rank=1, section_path=["Combat", "Initiative"])
-    c3 = _make_candidate("chunk::combat::002", rank=2, section_path=["Combat", "AoO"])
+    c1 = _make_candidate("chunk::003", rank=3, section_path=["Combat", "Damage"])
+    c2 = _make_candidate("chunk::001", rank=1, section_path=["Combat", "Initiative"])
+    c3 = _make_candidate("chunk::002", rank=2, section_path=["Combat", "AoO"])
 
     groups = shape_candidates([c1, c2, c3])
 
@@ -94,12 +98,59 @@ def test_shape_preserves_rank_order_within_group():
 
 
 # ---------------------------------------------------------------------------
+# Cross-document / cross-source isolation
+# ---------------------------------------------------------------------------
+
+
+def test_same_section_root_different_documents_produce_separate_groups():
+    """Two documents both having 'Combat' as section root must NOT merge."""
+    c1 = _make_candidate(
+        "chunk::srd::001", rank=1,
+        section_path=["Combat", "Initiative"],
+        document_id="doc::srd_combat",
+    )
+    c2 = _make_candidate(
+        "chunk::phb::001", rank=2,
+        section_path=["Combat", "Actions in Combat"],
+        document_id="doc::phb_combat",
+    )
+
+    groups = shape_candidates([c1, c2])
+
+    assert len(groups) == 2, (
+        "Same section_root from different documents should produce separate groups"
+    )
+    assert {g.document_id for g in groups} == {"doc::srd_combat", "doc::phb_combat"}
+
+
+def test_same_document_same_section_root_merge_into_one_group():
+    """Two candidates from the same document and section root → one group."""
+    c1 = _make_candidate(
+        "chunk::001", rank=1,
+        section_path=["Combat", "Initiative"],
+        document_id="doc::srd_combat",
+    )
+    c2 = _make_candidate(
+        "chunk::002", rank=3,
+        section_path=["Combat", "AoO"],
+        document_id="doc::srd_combat",
+    )
+
+    groups = shape_candidates([c1, c2])
+
+    assert len(groups) == 1
+    assert groups[0].document_id == "doc::srd_combat"
+    assert groups[0].section_root == "Combat"
+    assert groups[0].size == 2
+
+
+# ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
 
 
 def test_shape_handles_empty_section_path():
-    c = _make_candidate("chunk::unknown::001", rank=1, section_path=[])
+    c = _make_candidate("chunk::001", rank=1, section_path=[])
     groups = shape_candidates([c])
 
     assert len(groups) == 1
@@ -108,7 +159,11 @@ def test_shape_handles_empty_section_path():
 
 def test_shape_handles_many_section_roots():
     candidates = [
-        _make_candidate(f"chunk::s{i}::001", rank=i, section_path=[f"Section{i}", "Sub"])
+        _make_candidate(
+            f"chunk::s{i}::001", rank=i,
+            section_path=[f"Section{i}", "Sub"],
+            document_id=f"doc::s{i}",
+        )
         for i in range(1, 6)
     ]
     groups = shape_candidates(candidates)


### PR DESCRIPTION
## Summary
- Adds `shape_candidates()` which groups `LexicalCandidate` objects by section root (first element of `section_path`)
- New `CandidateGroup` dataclass with `section_root`, `candidates`, `best_rank`, and `size` property
- Groups sorted by best rank; candidates within each group sorted by rank
- 8 unit tests covering basic grouping, rank ordering, edge cases (empty path, many roots), and package export

## Closes
Closes #44

## Dependencies
Depends on PR #61 (`issue-46-structure-metadata`)

## Test plan
- [x] `pytest tests/test_candidate_shaping.py -v` — 8 passed
- [x] Full test suite — 179 passed, 1 xfailed
- [ ] Reviewer: verify grouping logic handles edge cases correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)