### PR TITLE
feat(retrieval): same-document candidate consolidation (#34)

### DIFF
--- a/scripts/retrieval/__init__.py
+++ b/scripts/retrieval/__init__.py
@@ -1,3 +1,8 @@
+from .candidate_consolidation import (
+    ConsolidatedCandidate,
+    ConsolidatedGroup,
+    consolidate_candidates,
+)
 from .candidate_shaping import CandidateGroup, shape_candidates
 from .contracts import LexicalCandidate, NormalizedQuery
 from .filters import (
@@ -14,6 +19,9 @@ __all__ = [
     "apply_filters",
     "build_constraints",
     "CandidateGroup",
+    "consolidate_candidates",
+    "ConsolidatedCandidate",
+    "ConsolidatedGroup",
     "FilterResult",
     "get_default_term_assets",
     "LexicalCandidate",

--- a/scripts/retrieval/candidate_consolidation.py
+++ b/scripts/retrieval/candidate_consolidation.py
@@ -47,6 +47,7 @@ class ConsolidatedCandidate:
 class ConsolidatedGroup:
     """A CandidateGroup after consolidation."""
 
+    document_id: str
     section_root: str
     candidates: list[ConsolidatedCandidate]
     dropped_count: int = 0
@@ -81,6 +82,7 @@ def _consolidate_group(group: CandidateGroup) -> ConsolidatedGroup:
     dropped = len(group.candidates) - len(consolidated)
 
     return ConsolidatedGroup(
+        document_id=group.document_id,
         section_root=group.section_root,
         candidates=consolidated,
         dropped_count=dropped,

--- a/scripts/retrieval/candidate_consolidation.py
+++ b/scripts/retrieval/candidate_consolidation.py
@@ -4,13 +4,19 @@ Operates on CandidateGroup objects from shape_candidates().  Reduces
 overlap-heavy candidate sets so the same evidence is not counted multiple
 times in the evidence pack.
 
-Phase 1 consolidation rules (applied per group):
+Phase 1 consolidation rule (applied per group):
 1. Same-document dedup: if multiple candidates come from the same
    document_id, keep only the highest-ranked one and record the others
    as merged.
 
-Provenance is preserved: ConsolidatedCandidate tracks all merged chunk_ids
-and the reason for merging, so debug/inspection can show what was dropped.
+Future consolidation rules (not yet implemented):
+- Near-duplicate collapse (content similarity)
+- Adjacent chunk consolidation (prev/next links)
+- Same-section grouping refinements
+
+Lightweight provenance is preserved: ConsolidatedCandidate tracks merged
+chunk_ids and the merge reason.  Dropped candidates' ranks, scores, and
+match signals are not retained — expand if needed for debugging.
 """
 from __future__ import annotations
 
@@ -50,7 +56,7 @@ class ConsolidatedGroup:
         return len(self.candidates)
 
 
-def consolidate_group(group: CandidateGroup) -> ConsolidatedGroup:
+def _consolidate_group(group: CandidateGroup) -> ConsolidatedGroup:
     """Consolidate a single candidate group by collapsing same-document duplicates.
 
     The first-seen candidate per document_id becomes the representative,
@@ -88,4 +94,4 @@ def consolidate_candidates(
 
     Returns consolidated groups in the same order as the input.
     """
-    return [consolidate_group(g) for g in groups]
+    return [_consolidate_group(g) for g in groups]

--- a/scripts/retrieval/candidate_consolidation.py
+++ b/scripts/retrieval/candidate_consolidation.py
@@ -51,10 +51,15 @@ class ConsolidatedGroup:
 
 
 def consolidate_group(group: CandidateGroup) -> ConsolidatedGroup:
-    """Consolidate a single candidate group by collapsing same-document duplicates."""
+    """Consolidate a single candidate group by collapsing same-document duplicates.
+
+    The first-seen candidate per document_id becomes the representative,
+    so candidates must be rank-ordered (ascending).  We sort defensively
+    rather than relying on the upstream contract.
+    """
     seen: dict[str, ConsolidatedCandidate] = {}
 
-    for candidate in group.candidates:
+    for candidate in sorted(group.candidates, key=lambda c: c.rank):
         doc_id = candidate.document_id
         if doc_id not in seen:
             seen[doc_id] = ConsolidatedCandidate(

--- a/scripts/retrieval/candidate_consolidation.py
+++ b/scripts/retrieval/candidate_consolidation.py
@@ -1,0 +1,86 @@
+"""Post-shaping candidate consolidation: reduce overlap within groups.
+
+Operates on CandidateGroup objects from shape_candidates().  Reduces
+overlap-heavy candidate sets so the same evidence is not counted multiple
+times in the evidence pack.
+
+Phase 1 consolidation rules (applied per group):
+1. Same-document dedup: if multiple candidates come from the same
+   document_id, keep only the highest-ranked one and record the others
+   as merged.
+
+Provenance is preserved: ConsolidatedCandidate tracks all merged chunk_ids
+and the reason for merging, so debug/inspection can show what was dropped.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .candidate_shaping import CandidateGroup
+from .contracts import LexicalCandidate
+
+
+@dataclass
+class ConsolidatedCandidate:
+    """A candidate that may represent one or more original candidates."""
+
+    representative: LexicalCandidate
+    merged_chunk_ids: list[str]
+    merge_reason: str
+
+    @property
+    def chunk_id(self) -> str:
+        return self.representative.chunk_id
+
+    @property
+    def rank(self) -> int:
+        return self.representative.rank
+
+
+@dataclass
+class ConsolidatedGroup:
+    """A CandidateGroup after consolidation."""
+
+    section_root: str
+    candidates: list[ConsolidatedCandidate]
+    dropped_count: int = 0
+
+    @property
+    def size(self) -> int:
+        return len(self.candidates)
+
+
+def consolidate_group(group: CandidateGroup) -> ConsolidatedGroup:
+    """Consolidate a single candidate group by collapsing same-document duplicates."""
+    seen: dict[str, ConsolidatedCandidate] = {}
+
+    for candidate in group.candidates:
+        doc_id = candidate.document_id
+        if doc_id not in seen:
+            seen[doc_id] = ConsolidatedCandidate(
+                representative=candidate,
+                merged_chunk_ids=[candidate.chunk_id],
+                merge_reason="unique",
+            )
+        else:
+            seen[doc_id].merged_chunk_ids.append(candidate.chunk_id)
+            seen[doc_id].merge_reason = "same_document"
+
+    consolidated = sorted(seen.values(), key=lambda c: c.rank)
+    dropped = len(group.candidates) - len(consolidated)
+
+    return ConsolidatedGroup(
+        section_root=group.section_root,
+        candidates=consolidated,
+        dropped_count=dropped,
+    )
+
+
+def consolidate_candidates(
+    groups: list[CandidateGroup],
+) -> list[ConsolidatedGroup]:
+    """Consolidate all candidate groups.
+
+    Returns consolidated groups in the same order as the input.
+    """
+    return [consolidate_group(g) for g in groups]

--- a/tests/test_candidate_consolidation.py
+++ b/tests/test_candidate_consolidation.py
@@ -1,0 +1,172 @@
+"""Tests for candidate consolidation (issue #34)."""
+from __future__ import annotations
+
+from scripts.retrieval.candidate_consolidation import (
+    ConsolidatedCandidate,
+    ConsolidatedGroup,
+    consolidate_candidates,
+    consolidate_group,
+)
+from scripts.retrieval.candidate_shaping import CandidateGroup
+from scripts.retrieval.contracts import LexicalCandidate
+
+
+def _make_candidate(
+    chunk_id: str,
+    document_id: str,
+    rank: int,
+    section_path: list[str] | None = None,
+) -> LexicalCandidate:
+    return LexicalCandidate(
+        chunk_id=chunk_id,
+        document_id=document_id,
+        rank=rank,
+        raw_score=-1.0,
+        score_direction="lower_is_better",
+        chunk_type="subsection",
+        source_ref={
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        locator={
+            "section_path": section_path or ["Combat", "Test"],
+            "source_location": "test",
+        },
+        match_signals={
+            "exact_phrase_hits": [],
+            "protected_phrase_hits": [],
+            "section_path_hit": False,
+            "token_overlap_count": 0,
+        },
+    )
+
+
+def _make_group(
+    section_root: str,
+    candidates: list[LexicalCandidate],
+) -> CandidateGroup:
+    return CandidateGroup(
+        section_root=section_root,
+        candidates=candidates,
+        best_rank=candidates[0].rank if candidates else 0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# consolidate_group
+# ---------------------------------------------------------------------------
+
+
+def test_consolidate_group_no_duplicates():
+    """All unique document_ids → nothing dropped."""
+    candidates = [
+        _make_candidate("chunk::001", "doc::001", rank=1),
+        _make_candidate("chunk::002", "doc::002", rank=2),
+    ]
+    group = _make_group("Combat", candidates)
+    result = consolidate_group(group)
+
+    assert result.size == 2
+    assert result.dropped_count == 0
+    assert all(c.merge_reason == "unique" for c in result.candidates)
+
+
+def test_consolidate_group_merges_same_document():
+    """Two candidates from the same document_id → merged into one."""
+    candidates = [
+        _make_candidate("chunk::001", "doc::combat", rank=1),
+        _make_candidate("chunk::002", "doc::combat", rank=2),
+        _make_candidate("chunk::003", "doc::spells", rank=3),
+    ]
+    group = _make_group("Combat", candidates)
+    result = consolidate_group(group)
+
+    assert result.size == 2
+    assert result.dropped_count == 1
+
+    # The representative should be the higher-ranked one
+    combat_consolidated = [c for c in result.candidates if c.chunk_id == "chunk::001"][0]
+    assert combat_consolidated.merged_chunk_ids == ["chunk::001", "chunk::002"]
+    assert combat_consolidated.merge_reason == "same_document"
+    assert combat_consolidated.rank == 1
+
+
+def test_consolidate_group_preserves_rank_order():
+    """Consolidated candidates are sorted by rank."""
+    candidates = [
+        _make_candidate("chunk::003", "doc::spells", rank=3),
+        _make_candidate("chunk::001", "doc::combat", rank=1),
+        _make_candidate("chunk::002", "doc::combat", rank=2),
+    ]
+    group = _make_group("Mixed", candidates)
+    result = consolidate_group(group)
+
+    ranks = [c.rank for c in result.candidates]
+    assert ranks == sorted(ranks)
+
+
+def test_consolidate_group_preserves_provenance():
+    """All original chunk_ids are recorded in merged_chunk_ids."""
+    candidates = [
+        _make_candidate("chunk::001", "doc::combat", rank=1),
+        _make_candidate("chunk::002", "doc::combat", rank=2),
+        _make_candidate("chunk::003", "doc::combat", rank=3),
+    ]
+    group = _make_group("Combat", candidates)
+    result = consolidate_group(group)
+
+    assert result.size == 1
+    assert result.dropped_count == 2
+    assert result.candidates[0].merged_chunk_ids == [
+        "chunk::001", "chunk::002", "chunk::003"
+    ]
+
+
+def test_consolidate_group_empty():
+    group = _make_group("Empty", [])
+    result = consolidate_group(group)
+    assert result.size == 0
+    assert result.dropped_count == 0
+
+
+# ---------------------------------------------------------------------------
+# consolidate_candidates
+# ---------------------------------------------------------------------------
+
+
+def test_consolidate_candidates_processes_all_groups():
+    groups = [
+        _make_group("Combat", [
+            _make_candidate("chunk::001", "doc::001", rank=1),
+        ]),
+        _make_group("Spells", [
+            _make_candidate("chunk::002", "doc::002", rank=2),
+            _make_candidate("chunk::003", "doc::002", rank=3),
+        ]),
+    ]
+    results = consolidate_candidates(groups)
+
+    assert len(results) == 2
+    assert results[0].section_root == "Combat"
+    assert results[0].size == 1
+    assert results[1].section_root == "Spells"
+    assert results[1].size == 1
+    assert results[1].dropped_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Public export
+# ---------------------------------------------------------------------------
+
+
+def test_consolidation_importable_from_package():
+    from scripts.retrieval import (
+        ConsolidatedCandidate as CC,
+        ConsolidatedGroup as CG,
+        consolidate_candidates as cc,
+    )
+    assert cc is consolidate_candidates
+    assert CC is ConsolidatedCandidate
+    assert CG is ConsolidatedGroup

--- a/tests/test_candidate_consolidation.py
+++ b/tests/test_candidate_consolidation.py
@@ -46,8 +46,10 @@ def _make_candidate(
 def _make_group(
     section_root: str,
     candidates: list[LexicalCandidate],
+    document_id: str = "doc::test",
 ) -> CandidateGroup:
     return CandidateGroup(
+        document_id=document_id,
         section_root=section_root,
         candidates=candidates,
         best_rank=candidates[0].rank if candidates else 0,

--- a/tests/test_candidate_consolidation.py
+++ b/tests/test_candidate_consolidation.py
@@ -124,6 +124,21 @@ def test_consolidate_group_preserves_provenance():
     ]
 
 
+def test_consolidate_group_picks_best_rank_regardless_of_input_order():
+    """Even if the lower-ranked candidate appears first, the best-ranked wins."""
+    candidates = [
+        _make_candidate("chunk::002", "doc::combat", rank=5),
+        _make_candidate("chunk::001", "doc::combat", rank=1),
+    ]
+    group = _make_group("Combat", candidates)
+    result = consolidate_group(group)
+
+    assert result.size == 1
+    assert result.candidates[0].chunk_id == "chunk::001"
+    assert result.candidates[0].rank == 1
+    assert set(result.candidates[0].merged_chunk_ids) == {"chunk::001", "chunk::002"}
+
+
 def test_consolidate_group_empty():
     group = _make_group("Empty", [])
     result = consolidate_group(group)

--- a/tests/test_candidate_consolidation.py
+++ b/tests/test_candidate_consolidation.py
@@ -1,11 +1,10 @@
-"""Tests for candidate consolidation (issue #34)."""
+"""Tests for candidate consolidation (issue #34, Phase 1: same-document dedup)."""
 from __future__ import annotations
 
 from scripts.retrieval.candidate_consolidation import (
     ConsolidatedCandidate,
     ConsolidatedGroup,
     consolidate_candidates,
-    consolidate_group,
 )
 from scripts.retrieval.candidate_shaping import CandidateGroup
 from scripts.retrieval.contracts import LexicalCandidate
@@ -56,68 +55,68 @@ def _make_group(
     )
 
 
+def _consolidate_one(group: CandidateGroup) -> ConsolidatedGroup:
+    """Consolidate a single group via the public batch API."""
+    return consolidate_candidates([group])[0]
+
+
 # ---------------------------------------------------------------------------
-# consolidate_group
+# Same-document dedup
 # ---------------------------------------------------------------------------
 
 
-def test_consolidate_group_no_duplicates():
-    """All unique document_ids → nothing dropped."""
+def test_no_duplicates():
+    """All unique document_ids -> nothing dropped."""
     candidates = [
         _make_candidate("chunk::001", "doc::001", rank=1),
         _make_candidate("chunk::002", "doc::002", rank=2),
     ]
-    group = _make_group("Combat", candidates)
-    result = consolidate_group(group)
+    result = _consolidate_one(_make_group("Combat", candidates))
 
     assert result.size == 2
     assert result.dropped_count == 0
     assert all(c.merge_reason == "unique" for c in result.candidates)
 
 
-def test_consolidate_group_merges_same_document():
-    """Two candidates from the same document_id → merged into one."""
+def test_merges_same_document():
+    """Two candidates from the same document_id -> merged into one."""
     candidates = [
         _make_candidate("chunk::001", "doc::combat", rank=1),
         _make_candidate("chunk::002", "doc::combat", rank=2),
         _make_candidate("chunk::003", "doc::spells", rank=3),
     ]
-    group = _make_group("Combat", candidates)
-    result = consolidate_group(group)
+    result = _consolidate_one(_make_group("Combat", candidates))
 
     assert result.size == 2
     assert result.dropped_count == 1
 
-    # The representative should be the higher-ranked one
     combat_consolidated = [c for c in result.candidates if c.chunk_id == "chunk::001"][0]
     assert combat_consolidated.merged_chunk_ids == ["chunk::001", "chunk::002"]
     assert combat_consolidated.merge_reason == "same_document"
     assert combat_consolidated.rank == 1
 
 
-def test_consolidate_group_preserves_rank_order():
+def test_preserves_rank_order():
     """Consolidated candidates are sorted by rank."""
     candidates = [
         _make_candidate("chunk::003", "doc::spells", rank=3),
         _make_candidate("chunk::001", "doc::combat", rank=1),
         _make_candidate("chunk::002", "doc::combat", rank=2),
     ]
-    group = _make_group("Mixed", candidates)
-    result = consolidate_group(group)
+    result = _consolidate_one(_make_group("Mixed", candidates))
 
     ranks = [c.rank for c in result.candidates]
     assert ranks == sorted(ranks)
 
 
-def test_consolidate_group_preserves_provenance():
+def test_preserves_provenance():
     """All original chunk_ids are recorded in merged_chunk_ids."""
     candidates = [
         _make_candidate("chunk::001", "doc::combat", rank=1),
         _make_candidate("chunk::002", "doc::combat", rank=2),
         _make_candidate("chunk::003", "doc::combat", rank=3),
     ]
-    group = _make_group("Combat", candidates)
-    result = consolidate_group(group)
+    result = _consolidate_one(_make_group("Combat", candidates))
 
     assert result.size == 1
     assert result.dropped_count == 2
@@ -126,14 +125,13 @@ def test_consolidate_group_preserves_provenance():
     ]
 
 
-def test_consolidate_group_picks_best_rank_regardless_of_input_order():
+def test_picks_best_rank_regardless_of_input_order():
     """Even if the lower-ranked candidate appears first, the best-ranked wins."""
     candidates = [
         _make_candidate("chunk::002", "doc::combat", rank=5),
         _make_candidate("chunk::001", "doc::combat", rank=1),
     ]
-    group = _make_group("Combat", candidates)
-    result = consolidate_group(group)
+    result = _consolidate_one(_make_group("Combat", candidates))
 
     assert result.size == 1
     assert result.candidates[0].chunk_id == "chunk::001"
@@ -141,15 +139,14 @@ def test_consolidate_group_picks_best_rank_regardless_of_input_order():
     assert set(result.candidates[0].merged_chunk_ids) == {"chunk::001", "chunk::002"}
 
 
-def test_consolidate_group_empty():
-    group = _make_group("Empty", [])
-    result = consolidate_group(group)
+def test_empty_group():
+    result = _consolidate_one(_make_group("Empty", []))
     assert result.size == 0
     assert result.dropped_count == 0
 
 
 # ---------------------------------------------------------------------------
-# consolidate_candidates
+# Batch consolidation
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Implements **Phase 1** of issue #34: same-document dedup within each `CandidateGroup`
- Keeps the highest-ranked representative per document, records all original `chunk_id`s in `merged_chunk_ids`
- `ConsolidatedCandidate` and `ConsolidatedGroup` dataclasses with lightweight provenance tracking (`merge_reason` + `merged_chunk_ids`; dropped candidates' ranks/scores/signals are not retained)
- 8 unit tests covering no-dups, same-document merge, rank ordering, provenance, reverse-order input, empty groups, multi-group batch, and package export

## Scope note
This PR covers only same-document dedup (Phase 1). The remaining #34 scope — near-duplicate collapse, adjacent chunk consolidation — will be addressed in follow-up work. **Do not close #34 on merge.**

## Dependencies
Depends on PR #64 (`issue-44-candidate-shaping`)

## Test plan
- [x] `pytest tests/test_candidate_consolidation.py -v` — 8 passed
- [x] Full test suite — 183 passed, 1 xfailed
- [ ] Reviewer: verify consolidation preserves provenance correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)