### PR TITLE
feat(retrieval): evidence-pack contract and debug CLI (#35)

### DIFF
--- a/scripts/retrieval/__init__.py
+++ b/scripts/retrieval/__init__.py
@@ -1,5 +1,13 @@
 from .candidate_shaping import CandidateGroup, shape_candidates
 from .contracts import LexicalCandidate, NormalizedQuery
+from .evidence_pack import (
+    EvidenceItem,
+    EvidencePack,
+    GroupSummary,
+    PipelineTrace,
+    build_evidence_pack,
+    retrieve_evidence,
+)
 from .filters import (
     apply_filters,
     build_constraints,
@@ -13,13 +21,19 @@ from .term_assets import get_default_term_assets, load_term_assets
 __all__ = [
     "apply_filters",
     "build_constraints",
+    "build_evidence_pack",
     "CandidateGroup",
+    "EvidenceItem",
+    "EvidencePack",
     "FilterResult",
     "get_default_term_assets",
+    "GroupSummary",
     "LexicalCandidate",
     "load_term_assets",
     "normalize_query",
     "NormalizedQuery",
+    "PipelineTrace",
+    "retrieve_evidence",
     "retrieve_lexical",
     "RetrievalConstraints",
     "shape_candidates",

--- a/scripts/retrieval/evidence_pack.py
+++ b/scripts/retrieval/evidence_pack.py
@@ -13,11 +13,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-logger = logging.getLogger(__name__)
-
-from .candidate_shaping import CandidateGroup
+from .candidate_shaping import CandidateGroup, shape_candidates
 from .contracts import MatchSignals, NormalizedQuery
-from .filters import RetrievalConstraints
+from .filters import RetrievalConstraints, build_constraints
+from .lexical_retriever import DEFAULT_DB_PATH, retrieve_lexical
+from .query_normalization import normalize_query
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -64,7 +66,7 @@ class EvidencePack:
 
     query: NormalizedQuery
     constraints_summary: dict[str, Any]
-    evidence: list[EvidenceItem]
+    evidence: tuple[EvidenceItem, ...]
     trace: PipelineTrace
 
 
@@ -120,6 +122,7 @@ def build_evidence_pack(
     """
     evidence: list[EvidenceItem] = []
     summaries: list[GroupSummary] = []
+    missing_chunk_ids: list[str] = []
 
     for group in groups:
         summaries.append(
@@ -132,10 +135,7 @@ def build_evidence_pack(
         for candidate in group.candidates:
             content = content_lookup.get(candidate.chunk_id, "")
             if not content:
-                logger.warning(
-                    "No content found for chunk %s; evidence item will have empty content",
-                    candidate.chunk_id,
-                )
+                missing_chunk_ids.append(candidate.chunk_id)
             evidence.append(
                 EvidenceItem(
                     chunk_id=candidate.chunk_id,
@@ -150,6 +150,13 @@ def build_evidence_pack(
                 )
             )
 
+    if missing_chunk_ids:
+        logger.warning(
+            "No content found for %d chunk(s); evidence items will have empty content: %s",
+            len(missing_chunk_ids),
+            missing_chunk_ids,
+        )
+
     trace = PipelineTrace(
         total_candidates=total_candidates,
         group_count=len(groups),
@@ -158,12 +165,12 @@ def build_evidence_pack(
 
     # Sort evidence globally by rank so consumers can iterate as-ranked
     # without needing to re-sort across groups.
-    evidence.sort(key=lambda e: e.rank)
+    sorted_evidence = tuple(sorted(evidence, key=lambda e: e.rank))
 
     return EvidencePack(
         query=query,
         constraints_summary=_constraints_to_summary(constraints),
-        evidence=evidence,
+        evidence=sorted_evidence,
         trace=trace,
     )
 
@@ -179,11 +186,6 @@ def retrieve_evidence(
     Runs normalization → lexical retrieval → shaping → evidence pack
     assembly in one call.
     """
-    from .candidate_shaping import shape_candidates
-    from .filters import build_constraints
-    from .lexical_retriever import DEFAULT_DB_PATH, retrieve_lexical
-    from .query_normalization import normalize_query
-
     norm_payload = normalize_query(raw_query)
     query = NormalizedQuery.from_query_normalization(norm_payload)
     constraints = build_constraints()

--- a/scripts/retrieval/evidence_pack.py
+++ b/scripts/retrieval/evidence_pack.py
@@ -1,0 +1,210 @@
+"""Evidence-pack contract: retrieval-to-answer handoff.
+
+The evidence pack wraps the final shaped retrieval output with enough
+context for answer generation to produce grounded, cited answers without
+re-querying the index.  It also carries a pipeline trace so retrieval
+behaviour is inspectable via the debug CLI.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+from .candidate_shaping import CandidateGroup
+from .contracts import MatchSignals, NormalizedQuery
+from .filters import RetrievalConstraints
+
+
+@dataclass(frozen=True)
+class EvidenceItem:
+    """A single piece of evidence ready for answer generation."""
+
+    chunk_id: str
+    document_id: str
+    rank: int
+    content: str
+    chunk_type: str
+    source_ref: dict[str, Any]
+    locator: dict[str, Any]
+    match_signals: MatchSignals
+    section_root: str
+
+
+@dataclass(frozen=True)
+class GroupSummary:
+    """Lightweight summary of one candidate group for the pipeline trace."""
+
+    document_id: str
+    section_root: str
+    candidate_count: int
+
+
+@dataclass(frozen=True)
+class PipelineTrace:
+    """Diagnostic snapshot of the retrieval pipeline run."""
+
+    total_candidates: int
+    group_count: int
+    group_summaries: tuple[GroupSummary, ...]
+
+
+@dataclass(frozen=True)
+class EvidencePack:
+    """Complete retrieval-to-answer handoff contract.
+
+    Contains everything answer generation needs: the evidence items (with
+    content), query context, constraint summary, and a pipeline trace for
+    debugging.
+    """
+
+    query: NormalizedQuery
+    constraints_summary: dict[str, Any]
+    evidence: list[EvidenceItem]
+    trace: PipelineTrace
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+def _fetch_content(db_path: Path, chunk_ids: list[str]) -> dict[str, str]:
+    """Look up chunk content from the lexical index for a set of chunk_ids."""
+    if not chunk_ids:
+        return {}
+    placeholders = ",".join("?" for _ in chunk_ids)
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            f"SELECT chunk_id, content FROM chunk_metadata WHERE chunk_id IN ({placeholders})",
+            chunk_ids,
+        ).fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+def _constraints_to_summary(constraints: RetrievalConstraints) -> dict[str, Any]:
+    return {
+        "editions": sorted(constraints.editions),
+        "source_types": sorted(constraints.source_types),
+        "authority_levels": sorted(constraints.authority_levels),
+        "excluded_source_ids": sorted(constraints.excluded_source_ids),
+    }
+
+
+def build_evidence_pack(
+    query: NormalizedQuery,
+    groups: list[CandidateGroup],
+    *,
+    constraints: RetrievalConstraints,
+    content_lookup: dict[str, str],
+    total_candidates: int,
+) -> EvidencePack:
+    """Assemble an evidence pack from shaped candidate groups.
+
+    Parameters
+    ----------
+    query:
+        The normalized query that produced the candidates.
+    groups:
+        Candidate groups from ``shape_candidates()``.
+    constraints:
+        The retrieval constraints that were applied.
+    content_lookup:
+        Mapping of chunk_id → content text for candidate chunks.
+    total_candidates:
+        Number of candidates that entered shaping.
+    """
+    evidence: list[EvidenceItem] = []
+    summaries: list[GroupSummary] = []
+
+    for group in groups:
+        summaries.append(
+            GroupSummary(
+                document_id=group.document_id,
+                section_root=group.section_root,
+                candidate_count=group.size,
+            )
+        )
+        for candidate in group.candidates:
+            content = content_lookup.get(candidate.chunk_id, "")
+            if not content:
+                logger.warning(
+                    "No content found for chunk %s; evidence item will have empty content",
+                    candidate.chunk_id,
+                )
+            evidence.append(
+                EvidenceItem(
+                    chunk_id=candidate.chunk_id,
+                    document_id=candidate.document_id,
+                    rank=candidate.rank,
+                    content=content,
+                    chunk_type=candidate.chunk_type,
+                    source_ref=candidate.source_ref,
+                    locator=candidate.locator,
+                    match_signals=candidate.match_signals,
+                    section_root=group.section_root,
+                )
+            )
+
+    trace = PipelineTrace(
+        total_candidates=total_candidates,
+        group_count=len(groups),
+        group_summaries=tuple(summaries),
+    )
+
+    # Sort evidence globally by rank so consumers can iterate as-ranked
+    # without needing to re-sort across groups.
+    evidence.sort(key=lambda e: e.rank)
+
+    return EvidencePack(
+        query=query,
+        constraints_summary=_constraints_to_summary(constraints),
+        evidence=evidence,
+        trace=trace,
+    )
+
+
+def retrieve_evidence(
+    raw_query: str,
+    *,
+    db_path: Path | None = None,
+    top_k: int = 10,
+) -> EvidencePack:
+    """Full pipeline: raw query string → evidence pack.
+
+    Runs normalization → lexical retrieval → shaping → evidence pack
+    assembly in one call.
+    """
+    from .candidate_shaping import shape_candidates
+    from .filters import build_constraints
+    from .lexical_retriever import DEFAULT_DB_PATH, retrieve_lexical
+    from .query_normalization import normalize_query
+
+    norm_payload = normalize_query(raw_query)
+    query = NormalizedQuery.from_query_normalization(norm_payload)
+    constraints = build_constraints()
+    effective_db = db_path or DEFAULT_DB_PATH
+
+    candidates = retrieve_lexical(
+        query, constraints=constraints, db_path=effective_db, top_k=top_k
+    )
+    groups = shape_candidates(candidates)
+
+    chunk_ids = [
+        candidate.chunk_id
+        for group in groups
+        for candidate in group.candidates
+    ]
+    content_lookup = _fetch_content(effective_db, chunk_ids)
+
+    return build_evidence_pack(
+        query,
+        groups,
+        constraints=constraints,
+        content_lookup=content_lookup,
+        total_candidates=len(candidates),
+    )

--- a/scripts/retrieve_debug.py
+++ b/scripts/retrieve_debug.py
@@ -18,6 +18,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
+from scripts.retrieval.contracts import MatchSignals
 from scripts.retrieval.evidence_pack import EvidencePack, retrieve_evidence
 
 
@@ -76,15 +77,15 @@ def _fmt_locator(locator: dict) -> str:
     return " | ".join(parts) if parts else str(locator)
 
 
-def _fmt_signals(signals: dict) -> str:
+def _fmt_signals(signals: MatchSignals) -> str:
     parts = []
-    if signals.get("section_path_hit"):
+    if signals["section_path_hit"]:
         parts.append("section_path_hit")
-    if ep := signals.get("exact_phrase_hits"):
+    if ep := signals["exact_phrase_hits"]:
         parts.append(f"exact={ep}")
-    if pp := signals.get("protected_phrase_hits"):
+    if pp := signals["protected_phrase_hits"]:
         parts.append(f"protected={pp}")
-    if tc := signals.get("token_overlap_count"):
+    if tc := signals["token_overlap_count"]:
         parts.append(f"token_overlap={tc}")
     return ", ".join(parts) if parts else "(none)"
 

--- a/scripts/retrieve_debug.py
+++ b/scripts/retrieve_debug.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Debug CLI for inspecting the retrieval pipeline.
+
+Usage:
+    python scripts/retrieve_debug.py "attack of opportunity"
+    python scripts/retrieve_debug.py "turn undead" --top-k 5
+    python scripts/retrieve_debug.py "fighter hit die" --json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+# Allow running from repo root without PYTHONPATH.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.retrieval.evidence_pack import EvidencePack, retrieve_evidence
+
+
+def _print_text(pack: EvidencePack) -> None:
+    q = pack.query
+    print("=" * 72)
+    print("QUERY")
+    print("=" * 72)
+    print(f"  Raw:        {q.raw_query}")
+    print(f"  Normalized: {q.normalized_text}")
+    print(f"  Tokens:     {q.tokens}")
+    if q.protected_phrases:
+        print(f"  Protected:  {q.protected_phrases}")
+    if q.aliases_applied:
+        print(f"  Aliases:    {q.aliases_applied}")
+
+    print()
+    print("=" * 72)
+    print("CONSTRAINTS")
+    print("=" * 72)
+    for key, value in pack.constraints_summary.items():
+        print(f"  {key}: {value}")
+
+    print()
+    print("=" * 72)
+    print("PIPELINE TRACE")
+    print("=" * 72)
+    t = pack.trace
+    print(f"  Candidates entering shaping: {t.total_candidates}")
+    print(f"  Groups formed:               {t.group_count}")
+    for gs in t.group_summaries:
+        print(f"    [{gs.document_id} / {gs.section_root}] {gs.candidate_count} items")
+
+    print()
+    print("=" * 72)
+    print(f"EVIDENCE ({len(pack.evidence)} items)")
+    print("=" * 72)
+    for i, item in enumerate(pack.evidence, 1):
+        print(f"\n--- Evidence #{i} (rank {item.rank}) ---")
+        print(f"  chunk_id:    {item.chunk_id}")
+        print(f"  document_id: {item.document_id}")
+        print(f"  chunk_type:  {item.chunk_type}")
+        print(f"  section:     {item.section_root}")
+        print(f"  locator:     {_fmt_locator(item.locator)}")
+        print(f"  signals:     {_fmt_signals(item.match_signals)}")
+        content_preview = textwrap.shorten(item.content, width=200, placeholder="…")
+        print(f"  content:     {content_preview}")
+
+
+def _fmt_locator(locator: dict) -> str:
+    parts = []
+    if sp := locator.get("section_path"):
+        parts.append(" > ".join(sp))
+    if sl := locator.get("source_location"):
+        parts.append(sl)
+    return " | ".join(parts) if parts else str(locator)
+
+
+def _fmt_signals(signals: dict) -> str:
+    parts = []
+    if signals.get("section_path_hit"):
+        parts.append("section_path_hit")
+    if ep := signals.get("exact_phrase_hits"):
+        parts.append(f"exact={ep}")
+    if pp := signals.get("protected_phrase_hits"):
+        parts.append(f"protected={pp}")
+    if tc := signals.get("token_overlap_count"):
+        parts.append(f"token_overlap={tc}")
+    return ", ".join(parts) if parts else "(none)"
+
+
+def _to_json(pack: EvidencePack) -> dict:
+    return {
+        "query": {
+            "raw": pack.query.raw_query,
+            "normalized": pack.query.normalized_text,
+            "tokens": pack.query.tokens,
+            "protected_phrases": pack.query.protected_phrases,
+            "aliases_applied": pack.query.aliases_applied,
+        },
+        "constraints": pack.constraints_summary,
+        "trace": {
+            "total_candidates": pack.trace.total_candidates,
+            "group_count": pack.trace.group_count,
+            "groups": [
+                {
+                    "document_id": gs.document_id,
+                    "section_root": gs.section_root,
+                    "candidate_count": gs.candidate_count,
+                }
+                for gs in pack.trace.group_summaries
+            ],
+        },
+        "evidence": [
+            {
+                "rank": item.rank,
+                "chunk_id": item.chunk_id,
+                "document_id": item.document_id,
+                "chunk_type": item.chunk_type,
+                "section_root": item.section_root,
+                "source_ref": item.source_ref,
+                "locator": item.locator,
+                "match_signals": dict(item.match_signals),
+                "content": item.content,
+            }
+            for item in pack.evidence
+        ],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Inspect retrieval pipeline results for a query."
+    )
+    parser.add_argument("query", help="The query string to retrieve evidence for")
+    parser.add_argument(
+        "--top-k", type=int, default=10, help="Number of candidates (default: 10)"
+    )
+    parser.add_argument(
+        "--db", type=str, default=None, help="Path to lexical.db (default: auto)"
+    )
+    parser.add_argument(
+        "--json", action="store_true", dest="json_output", help="Output as JSON"
+    )
+    args = parser.parse_args()
+
+    db_path = Path(args.db) if args.db else None
+    effective_db = db_path or (REPO_ROOT / "data" / "index" / "srd_35" / "lexical.db")
+    if not effective_db.exists():
+        print(
+            f"Error: lexical.db not found at {effective_db}\n"
+            "Run the indexing pipeline first:\n"
+            "  python scripts/chunk_srd_35.py",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    pack = retrieve_evidence(args.query, db_path=db_path, top_k=args.top_k)
+
+    if args.json_output:
+        print(json.dumps(_to_json(pack), indent=2, ensure_ascii=False))
+    else:
+        _print_text(pack)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_evidence_pack.py
+++ b/tests/test_evidence_pack.py
@@ -283,6 +283,93 @@ def test_source_ref_carries_title_for_citation():
 
 
 # ---------------------------------------------------------------------------
+# retrieve_evidence orchestrator
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_evidence_end_to_end(tmp_path):
+    """End-to-end: raw query string → EvidencePack with hydrated content."""
+    import json as _json
+
+    from scripts.retrieval.evidence_pack import retrieve_evidence
+    from scripts.retrieval.lexical_index import build_chunk_index
+
+    chunk = {
+        "chunk_id": "chunk::srd_35::combat::001_attack_of_opportunity",
+        "document_id": "srd_35::combat",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "source_location": "Combat.rtf#001",
+        },
+        "chunk_type": "rule_section",
+        "content": "An attack of opportunity is a single melee attack.",
+    }
+    chunk_path = tmp_path / "aoo.json"
+    chunk_path.write_text(_json.dumps(chunk), encoding="utf-8")
+    db_path = tmp_path / "retrieval.db"
+    build_chunk_index(db_path, [chunk_path])
+
+    pack = retrieve_evidence("attack of opportunity", db_path=db_path, top_k=5)
+
+    assert len(pack.evidence) == 1
+    item = pack.evidence[0]
+    assert item.chunk_id == chunk["chunk_id"]
+    assert item.content == chunk["content"]
+    assert item.section_root == "Combat"
+    assert item.rank == 1
+
+    assert pack.trace.total_candidates == 1
+    assert pack.trace.group_count == 1
+    assert pack.trace.group_summaries[0].candidate_count == 1
+
+    # Query context threaded through.
+    assert pack.query.raw_query == "attack of opportunity"
+
+
+def test_retrieve_evidence_empty_for_no_match(tmp_path):
+    """retrieve_evidence returns a pack with empty evidence when no chunks match."""
+    import json as _json
+
+    from scripts.retrieval.evidence_pack import retrieve_evidence
+    from scripts.retrieval.lexical_index import build_chunk_index
+
+    chunk = {
+        "chunk_id": "chunk::srd_35::combat::001_attack_of_opportunity",
+        "document_id": "srd_35::combat",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "source_location": "Combat.rtf#001",
+        },
+        "chunk_type": "rule_section",
+        "content": "An attack of opportunity is a single melee attack.",
+    }
+    chunk_path = tmp_path / "aoo.json"
+    chunk_path.write_text(_json.dumps(chunk), encoding="utf-8")
+    db_path = tmp_path / "retrieval.db"
+    build_chunk_index(db_path, [chunk_path])
+
+    pack = retrieve_evidence("psionics", db_path=db_path, top_k=5)
+
+    assert pack.evidence == ()
+    assert pack.trace.total_candidates == 0
+    assert pack.trace.group_count == 0
+
+
+# ---------------------------------------------------------------------------
 # Public export
 # ---------------------------------------------------------------------------
 

--- a/tests/test_evidence_pack.py
+++ b/tests/test_evidence_pack.py
@@ -1,0 +1,303 @@
+"""Tests for evidence-pack contract (issue #35)."""
+from __future__ import annotations
+
+from scripts.retrieval.candidate_shaping import CandidateGroup
+from scripts.retrieval.contracts import LexicalCandidate, NormalizedQuery
+from scripts.retrieval.evidence_pack import (
+    EvidenceItem,
+    EvidencePack,
+    GroupSummary,
+    PipelineTrace,
+    build_evidence_pack,
+)
+from scripts.retrieval.filters import RetrievalConstraints
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_CONSTRAINTS = RetrievalConstraints(
+    editions=frozenset({"3.5e"}),
+    source_types=frozenset({"srd"}),
+    authority_levels=frozenset({"official_reference"}),
+    excluded_source_ids=frozenset(),
+)
+
+
+def _make_query(raw: str = "attack of opportunity") -> NormalizedQuery:
+    return NormalizedQuery(
+        raw_query=raw,
+        normalized_text="attack of opportunity",
+        tokens=["attack", "opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+
+
+def _make_candidate(
+    chunk_id: str,
+    document_id: str,
+    rank: int,
+    section_path: list[str] | None = None,
+) -> LexicalCandidate:
+    return LexicalCandidate(
+        chunk_id=chunk_id,
+        document_id=document_id,
+        rank=rank,
+        raw_score=-1.0,
+        score_direction="lower_is_better",
+        chunk_type="subsection",
+        source_ref={
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        locator={
+            "section_path": section_path or ["Combat", "Test"],
+            "source_location": "test",
+        },
+        match_signals={
+            "exact_phrase_hits": [],
+            "protected_phrase_hits": [],
+            "section_path_hit": False,
+            "token_overlap_count": 0,
+        },
+    )
+
+
+def _make_group(
+    section_root: str,
+    candidates: list[LexicalCandidate],
+    document_id: str = "doc::test",
+) -> CandidateGroup:
+    return CandidateGroup(
+        document_id=document_id,
+        section_root=section_root,
+        candidates=candidates,
+        best_rank=candidates[0].rank if candidates else 0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_evidence_pack
+# ---------------------------------------------------------------------------
+
+
+def test_build_evidence_pack_basic():
+    query = _make_query()
+    c1 = _make_candidate("chunk::001", "doc::001", rank=1)
+    c2 = _make_candidate("chunk::002", "doc::001", rank=2)
+    group = _make_group("Combat", [c1, c2], document_id="doc::001")
+
+    content_lookup = {
+        "chunk::001": "Attack of opportunity rules...",
+        "chunk::002": "More AoO details...",
+    }
+
+    pack = build_evidence_pack(
+        query,
+        [group],
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup=content_lookup,
+        total_candidates=2,
+    )
+
+    assert isinstance(pack, EvidencePack)
+    assert pack.query is query
+    assert len(pack.evidence) == 2
+    assert pack.evidence[0].chunk_id == "chunk::001"
+    assert pack.evidence[0].content == "Attack of opportunity rules..."
+    assert pack.evidence[1].content == "More AoO details..."
+
+
+def test_evidence_items_carry_section_root():
+    query = _make_query()
+    c1 = _make_candidate("chunk::001", "doc::combat", rank=1)
+    group = _make_group("Combat", [c1], document_id="doc::combat")
+
+    pack = build_evidence_pack(
+        query,
+        [group],
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup={"chunk::001": "content"},
+        total_candidates=1,
+    )
+
+    assert len(pack.evidence) == 1
+    assert pack.evidence[0].section_root == "Combat"
+
+
+def test_pipeline_trace_counts():
+    query = _make_query()
+    c1 = _make_candidate("chunk::001", "doc::combat", rank=1)
+    c2 = _make_candidate("chunk::002", "doc::combat", rank=2)
+    c3 = _make_candidate("chunk::003", "doc::spells", rank=3)
+    group_combat = _make_group("Combat", [c1, c2], document_id="doc::combat")
+    group_spells = _make_group("Spells", [c3], document_id="doc::spells")
+
+    pack = build_evidence_pack(
+        query,
+        [group_combat, group_spells],
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup={},
+        total_candidates=3,
+    )
+
+    assert pack.trace.total_candidates == 3
+    assert pack.trace.group_count == 2
+    assert len(pack.trace.group_summaries) == 2
+    assert pack.trace.group_summaries[0].document_id == "doc::combat"
+    assert pack.trace.group_summaries[0].section_root == "Combat"
+    assert pack.trace.group_summaries[0].candidate_count == 2
+    assert pack.trace.group_summaries[1].candidate_count == 1
+
+
+def test_constraints_summary():
+    query = _make_query()
+    pack = build_evidence_pack(
+        query,
+        [],
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup={},
+        total_candidates=0,
+    )
+
+    assert pack.constraints_summary["editions"] == ["3.5e"]
+    assert pack.constraints_summary["source_types"] == ["srd"]
+    assert pack.constraints_summary["authority_levels"] == ["official_reference"]
+    assert pack.constraints_summary["excluded_source_ids"] == []
+
+
+def test_empty_groups():
+    query = _make_query()
+    pack = build_evidence_pack(
+        query,
+        [],
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup={},
+        total_candidates=0,
+    )
+
+    assert len(pack.evidence) == 0
+    assert pack.trace.total_candidates == 0
+    assert pack.trace.group_count == 0
+    assert pack.trace.group_summaries == ()
+
+
+def test_missing_content_defaults_to_empty_string():
+    query = _make_query()
+    c1 = _make_candidate("chunk::001", "doc::001", rank=1)
+    group = _make_group("Combat", [c1], document_id="doc::001")
+
+    pack = build_evidence_pack(
+        query,
+        [group],
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup={},  # no content provided
+        total_candidates=1,
+    )
+
+    assert pack.evidence[0].content == ""
+
+
+def test_evidence_items_carry_match_signals():
+    query = _make_query()
+    c = LexicalCandidate(
+        chunk_id="chunk::sig",
+        document_id="doc::sig",
+        rank=1,
+        raw_score=-5.0,
+        score_direction="lower_is_better",
+        chunk_type="rule_section",
+        source_ref={
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        locator={"section_path": ["Combat", "AoO"], "source_location": "test"},
+        match_signals={
+            "exact_phrase_hits": ["attack of opportunity"],
+            "protected_phrase_hits": ["attack of opportunity"],
+            "section_path_hit": True,
+            "token_overlap_count": 2,
+        },
+    )
+    group = _make_group("Combat", [c], document_id="doc::sig")
+
+    pack = build_evidence_pack(
+        query,
+        [group],
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup={"chunk::sig": "AoO rules"},
+        total_candidates=1,
+    )
+
+    item = pack.evidence[0]
+    assert item.match_signals["section_path_hit"] is True
+    assert item.match_signals["exact_phrase_hits"] == ["attack of opportunity"]
+    assert item.chunk_type == "rule_section"
+
+
+def test_evidence_sorted_globally_by_rank():
+    """Evidence items from different groups are sorted by rank, not group order."""
+    query = _make_query()
+    # Group "Spells" has rank 1, group "Combat" has rank 2 — but pass Combat first
+    c_combat = _make_candidate("chunk::002", "doc::combat", rank=2)
+    c_spells = _make_candidate("chunk::001", "doc::spells", rank=1)
+    group_combat = _make_group("Combat", [c_combat], document_id="doc::combat")
+    group_spells = _make_group("Spells", [c_spells], document_id="doc::spells")
+
+    pack = build_evidence_pack(
+        query,
+        [group_combat, group_spells],  # Combat first, but rank 2
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup={},
+        total_candidates=2,
+    )
+
+    ranks = [e.rank for e in pack.evidence]
+    assert ranks == [1, 2], f"Evidence should be globally rank-sorted, got {ranks}"
+
+
+def test_source_ref_carries_title_for_citation():
+    """source_ref must include title — required by answer_with_citations schema."""
+    query = _make_query()
+    c = _make_candidate("chunk::001", "doc::001", rank=1)
+    group = _make_group("Combat", [c], document_id="doc::001")
+
+    pack = build_evidence_pack(
+        query,
+        [group],
+        constraints=_DEFAULT_CONSTRAINTS,
+        content_lookup={"chunk::001": "content"},
+        total_candidates=1,
+    )
+
+    assert "title" in pack.evidence[0].source_ref
+    assert pack.evidence[0].source_ref["title"] == "System Reference Document"
+
+
+# ---------------------------------------------------------------------------
+# Public export
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_pack_importable_from_package():
+    from scripts.retrieval import (
+        EvidenceItem as EI,
+        EvidencePack as EP,
+        GroupSummary as GS,
+        PipelineTrace as PT,
+        build_evidence_pack as bep,
+        retrieve_evidence as re_,
+    )
+    assert bep is build_evidence_pack
+    assert EI is EvidenceItem
+    assert EP is EvidencePack
+    assert GS is GroupSummary
+    assert PT is PipelineTrace


### PR DESCRIPTION
## Summary
- Adds `EvidencePack` as the retrieval-to-answer handoff contract: wraps shaped candidate groups with chunk content, query context, constraint summary, and a pipeline trace.
- `build_evidence_pack()` consumes `list[CandidateGroup]` directly from `shape_candidates()` — no consolidation layer between shape and pack.
- `retrieve_evidence()` runs the full pipeline (normalize → retrieve → shape → pack) in one call.
- `EvidenceItem`, `PipelineTrace`, `GroupSummary` contracts for structured pipeline output.
- `scripts/retrieve_debug.py` CLI for text / JSON inspection.
- 10 unit tests covering pack assembly, section_root propagation, trace counts, constraints summary, edge cases, global rank sort, and package export.

## Scope note
Consolidation / span fields (`merged_chunk_ids`, `merge_reason`, `dropped_count`, `total_after_consolidation`, `dropped_by_consolidation`) are intentionally not in the contract. They will be added when adjacent-chunk consolidation (remaining scope of #34) lands — at that point they will carry real span data.

## History
Originally stacked on #65. After #65 was closed as superseded by #64, this PR was rebased onto `master` and reworked to drop the consolidation layer. See the earlier status comment on this PR for the rationale.

## Closes
Closes #35

## Test plan
- [x] `pytest tests/test_evidence_pack.py -v` — 10 passed
- [x] Full test suite — 176 passed, 1 xfailed
- [x] `python -c "import scripts.retrieve_debug; import scripts.retrieval"` — import check clean
- [ ] Reviewer: verify evidence pack carries all info needed for answer generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)