### PR TITLE
feat(retrieval): propagate chunk-adjacency fields through LexicalCandidate (#67)

### DIFF
--- a/scripts/retrieval/contracts.py
+++ b/scripts/retrieval/contracts.py
@@ -47,3 +47,6 @@ class LexicalCandidate:
     source_ref: dict[str, Any]
     locator: dict[str, Any]
     match_signals: MatchSignals
+    parent_chunk_id: str | None = None
+    previous_chunk_id: str | None = None
+    next_chunk_id: str | None = None

--- a/scripts/retrieval/contracts.py
+++ b/scripts/retrieval/contracts.py
@@ -47,6 +47,8 @@ class LexicalCandidate:
     source_ref: dict[str, Any]
     locator: dict[str, Any]
     match_signals: MatchSignals
+    # Adjacency links: None for boundary chunks (first/last in section,
+    # top-level chunks with no parent). Source of truth: schemas/chunk.schema.json.
     parent_chunk_id: str | None = None
     previous_chunk_id: str | None = None
     next_chunk_id: str | None = None

--- a/scripts/retrieval/lexical_index.py
+++ b/scripts/retrieval/lexical_index.py
@@ -65,6 +65,9 @@ def search_chunk_index(db_path: Path, query_text: str, *, top_k: int = 5) -> lis
                 "section_path_hit": False,
                 "token_overlap_count": 0,
             },
+            parent_chunk_id=row.get("parent_chunk_id"),
+            previous_chunk_id=row.get("previous_chunk_id"),
+            next_chunk_id=row.get("next_chunk_id"),
         )
         for rank, row in enumerate(raw, start=1)
     ]

--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -131,9 +131,9 @@ def retrieve_lexical(
                 source_ref=row["source_ref"],
                 locator=row["locator"],
                 match_signals=signals,
-                parent_chunk_id=row["parent_chunk_id"],
-                previous_chunk_id=row["previous_chunk_id"],
-                next_chunk_id=row["next_chunk_id"],
+                parent_chunk_id=row.get("parent_chunk_id"),
+                previous_chunk_id=row.get("previous_chunk_id"),
+                next_chunk_id=row.get("next_chunk_id"),
             )
         )
 

--- a/scripts/retrieval/lexical_retriever.py
+++ b/scripts/retrieval/lexical_retriever.py
@@ -131,6 +131,9 @@ def retrieve_lexical(
                 source_ref=row["source_ref"],
                 locator=row["locator"],
                 match_signals=signals,
+                parent_chunk_id=row["parent_chunk_id"],
+                previous_chunk_id=row["previous_chunk_id"],
+                next_chunk_id=row["next_chunk_id"],
             )
         )
 

--- a/tests/test_lexical_retrieval.py
+++ b/tests/test_lexical_retrieval.py
@@ -202,6 +202,43 @@ def test_search_chunk_index_returns_ranked_candidates_from_fts(tmp_path, sample_
     assert results[0].raw_score <= 0
 
 
+def test_search_chunk_index_propagates_adjacency_fields(tmp_path, sample_chunk) -> None:
+    """search_chunk_index also surfaces the adjacency fields (contract parity
+    with retrieve_lexical)."""
+    chunk_with_links = {
+        **sample_chunk,
+        "previous_chunk_id": "chunk::srd_35::combat::000_intro",
+        "next_chunk_id": "chunk::srd_35::combat::002_flanking",
+        "parent_chunk_id": "chunk::srd_35::combat::000_root",
+    }
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", chunk_with_links)
+
+    build_chunk_index(db_path, [chunk_path])
+    results = search_chunk_index(db_path, "\"attack of opportunity\"", top_k=2)
+
+    assert len(results) == 1
+    candidate = results[0]
+    assert candidate.parent_chunk_id == "chunk::srd_35::combat::000_root"
+    assert candidate.previous_chunk_id == "chunk::srd_35::combat::000_intro"
+    assert candidate.next_chunk_id == "chunk::srd_35::combat::002_flanking"
+
+
+def test_search_chunk_index_adjacency_fields_null_when_absent(tmp_path, sample_chunk) -> None:
+    """A chunk with no adjacency links yields None from search_chunk_index."""
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+
+    build_chunk_index(db_path, [chunk_path])
+    results = search_chunk_index(db_path, "\"attack of opportunity\"", top_k=2)
+
+    assert len(results) == 1
+    candidate = results[0]
+    assert candidate.parent_chunk_id is None
+    assert candidate.previous_chunk_id is None
+    assert candidate.next_chunk_id is None
+
+
 def test_search_chunk_index_returns_empty_for_no_match(tmp_path, sample_chunk) -> None:
     db_path = tmp_path / "retrieval.db"
     chunk_path = _write_chunk(tmp_path / "attack_of_opportunity.json", sample_chunk)

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -367,6 +367,83 @@ def test_retrieve_lexical_respects_top_k(tmp_path, sample_chunk):
     assert [r.rank for r in results] == [1, 2, 3]
 
 
+def test_retrieve_lexical_propagates_adjacency_fields(tmp_path, sample_chunk):
+    """Adjacency fields from the index appear on the typed LexicalCandidate."""
+    chunk_with_links = {
+        **sample_chunk,
+        "previous_chunk_id": "chunk::srd_35::combat::000_intro",
+        "next_chunk_id": "chunk::srd_35::combat::002_flanking",
+        "parent_chunk_id": "chunk::srd_35::combat::000_root",
+    }
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", chunk_with_links)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 1
+    candidate = results[0]
+    assert candidate.parent_chunk_id == "chunk::srd_35::combat::000_root"
+    assert candidate.previous_chunk_id == "chunk::srd_35::combat::000_intro"
+    assert candidate.next_chunk_id == "chunk::srd_35::combat::002_flanking"
+
+
+def test_retrieve_lexical_adjacency_fields_null_when_absent(tmp_path, sample_chunk):
+    """A chunk with no adjacency links yields None on the candidate."""
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", sample_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 1
+    candidate = results[0]
+    assert candidate.parent_chunk_id is None
+    assert candidate.previous_chunk_id is None
+    assert candidate.next_chunk_id is None
+
+
+def test_retrieve_lexical_adjacency_fields_partially_null(tmp_path, sample_chunk):
+    """Boundary chunks: a first-in-section chunk has next and parent but no previous."""
+    first_chunk = {
+        **sample_chunk,
+        "next_chunk_id": "chunk::srd_35::combat::002_flanking",
+        "parent_chunk_id": "chunk::srd_35::combat::000_root",
+    }
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", first_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 1
+    candidate = results[0]
+    assert candidate.parent_chunk_id == "chunk::srd_35::combat::000_root"
+    assert candidate.previous_chunk_id is None
+    assert candidate.next_chunk_id == "chunk::srd_35::combat::002_flanking"
+
+
 def test_retrieve_lexical_reranks_after_filtering(tmp_path, sample_chunk):
     db_path = tmp_path / "retrieval.db"
     chunk_35 = sample_chunk

--- a/tests/test_lexical_retriever.py
+++ b/tests/test_lexical_retriever.py
@@ -444,6 +444,33 @@ def test_retrieve_lexical_adjacency_fields_partially_null(tmp_path, sample_chunk
     assert candidate.next_chunk_id == "chunk::srd_35::combat::002_flanking"
 
 
+def test_retrieve_lexical_adjacency_fields_last_in_section(tmp_path, sample_chunk):
+    """Boundary chunks: a last-in-section chunk has previous and parent but no next."""
+    last_chunk = {
+        **sample_chunk,
+        "previous_chunk_id": "chunk::srd_35::combat::000_intro",
+        "parent_chunk_id": "chunk::srd_35::combat::000_root",
+    }
+    db_path = tmp_path / "retrieval.db"
+    chunk_path = _write_chunk(tmp_path / "aoo.json", last_chunk)
+    build_chunk_index(db_path, [chunk_path])
+
+    query = NormalizedQuery(
+        raw_query="attack of opportunity",
+        normalized_text="attack of opportunity",
+        tokens=["attack of opportunity"],
+        protected_phrases=["attack of opportunity"],
+        aliases_applied=[],
+    )
+    results = retrieve_lexical(query, db_path=db_path, top_k=5)
+
+    assert len(results) == 1
+    candidate = results[0]
+    assert candidate.parent_chunk_id == "chunk::srd_35::combat::000_root"
+    assert candidate.previous_chunk_id == "chunk::srd_35::combat::000_intro"
+    assert candidate.next_chunk_id is None
+
+
 def test_retrieve_lexical_reranks_after_filtering(tmp_path, sample_chunk):
     db_path = tmp_path / "retrieval.db"
     chunk_35 = sample_chunk


### PR DESCRIPTION
## Summary
- Adds three optional fields to `LexicalCandidate`: `parent_chunk_id`, `previous_chunk_id`, `next_chunk_id`.
- `retrieve_lexical()` copies them through from the raw row returned by `_search_raw()` — no new queries, no schema changes.
- Three tests cover all-set / all-null / boundary-chunk (partial) cases.

## Why

The chunk index already stores these fields (`scripts/retrieval/lexical_index.py:17-19, 188-190`) and `_search_raw()` already returns them (lines 92-94, 116-118). The inline comment at `lexical_index.py:168-170` explicitly reserved them for *"future structure-aware retrieval."* Only the typed contract was dropping them.

Promoting them to first-class fields unblocks:
- **#34 adjacent-chunk consolidation** — requires prev/next on candidates to detect adjacency inside a `CandidateGroup`.
- **#35 evidence-pack debug output** — richer structure visibility in the debug CLI once consumers wire this up.

## Scope discipline

- No new consumers. No adjacency detection logic. That belongs to the downstream PR that actually uses these fields.
- No ingestion or index-schema changes — data was already there.
- No `path_depth` field or typed `SectionPath` view; `section_path` is already in `locator`.

## Closes
Closes #67

## Test plan
- [x] `pytest tests/test_lexical_retriever.py -v` — 37 passed, 1 xfailed (pre-existing chunker gap).
- [x] Full test suite — 169 passed, 1 xfailed.
- [ ] Reviewer: confirm the three new fields' null-default semantics match downstream expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)