### PR TITLE
docs: refresh status docs for phase 1 progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,13 @@ A private, personal RAG project for asking grounded questions about **Dungeons &
 
 ## Project status
 
-This repository is in **early implementation** (Phase 1 bootstrap path in progress).
+This repository is in **Phase 1 — Core Implementation**. Phase 0 design is complete.
 
-At this stage, the focus is:
+The core retrieval pipeline is now implemented: ingestion (`scripts/ingest_srd35/`), chunker (`scripts/chunker/`), lexical-first retrieval with domain-aware scoring and match-signal reranking (`scripts/retrieval/`), section-aware candidate shaping, structure-metadata indexing, and an evidence-pack contract with a retrieval debug CLI (`scripts/retrieve_debug.py`).
 
-- defining product scope
-- defining corpus and source boundaries
-- defining ingestion, chunking, retrieval, and citation strategy
-- defining evaluation criteria
+Still to come in Phase 1: answer generation with grounding, citation rendering, abstention behavior, and the evaluation run against the gold set.
 
-Design documents are still the source of truth, but ingestion and evaluation scaffolding are now implemented and used for regression evidence.
+Design documents remain authoritative for contracts; implementation is tracked against them via fixture corpora, golden tests, and recall-coverage evals.
 
 ## Vision
 
@@ -95,6 +92,7 @@ This repository is expected to grow around a small set of design documents.
 - `docs/evaluation_plan.md` — success criteria and evaluation approach
 - `docs/standards/pr_evidence.md` — minimum review evidence for pipeline PRs
 - `configs/source_registry.yaml` — tracked corpus sources and metadata
+- `evals/phase1_gold.yaml` — Phase 1 gold evaluation set over `srd_35`
 
 ## Initial product shape
 
@@ -152,4 +150,4 @@ Avoid:
 
 ## Next step
 
-The bootstrap source is pinned, the metadata contract is unified, and the Phase-1 gold evaluation set is committed. The immediate next step is to implement the first end-to-end baseline (rule-aware chunking + retrieval + evidence-pack QA) against `srd_35`.
+Ingestion, chunking, lexical retrieval, candidate shaping, and the evidence-pack contract are now in place against `srd_35`. The immediate next step is to close the Phase 1 loop: answer generation with grounding constraints, claim- / segment-level citation rendering, and abstention behavior, followed by the first evaluation run against `evals/phase1_gold.yaml`.

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,16 +6,13 @@
 
 ## 项目状态
 
-当前处于 **早期实现阶段**（Phase 1 基线路径进行中）。
+当前处于 **Phase 1 — 核心实现阶段**。Phase 0 设计已完成。
 
-当前重点：
+核心检索链路已落地：ingestion（`scripts/ingest_srd35/`）、chunker（`scripts/chunker/`）、带领域感知打分与 match-signal 重排的 lexical-first retrieval（`scripts/retrieval/`）、section-aware 的候选聚合、structure metadata 索引，以及 evidence-pack 契约与 retrieval debug CLI（`scripts/retrieve_debug.py`）。
 
-- 明确产品范围与边界
-- 固化语料与元数据契约
-- 推进 ingestion / evaluation 基础能力
-- 开始端到端 baseline（chunking + retrieval + evidence-pack QA）
+Phase 1 仍待完成：带 grounding 约束的 answer generation、citation 渲染、abstain 行为，以及在 gold set 上的首次评测运行。
 
-设计文档仍是主约束，但 ingestion 与评测证据链已经落地并用于回归。
+设计文档仍是契约的主约束；实现通过 fixture corpus、golden test 与 recall-coverage 回归加以对齐。
 
 ## 愿景
 
@@ -58,6 +55,7 @@ Phase 1 只在 3.5e 语料内工作。
 - `docs/evaluation_plan.md`：评测方案
 - `docs/standards/pr_evidence.md`：流水线 PR 的最低证据标准
 - `configs/source_registry.yaml`：来源注册表
+- `evals/phase1_gold.yaml`：`srd_35` 上的 Phase 1 gold 评测集
 
 ## 当前形态
 
@@ -69,4 +67,4 @@ Phase 1 只在 3.5e 语料内工作。
 
 ## 下一步
 
-当前最优先事项是推进 Issue #5：落地第一条端到端 baseline（rule-aware chunking + retrieval + evidence-pack QA），并在已提交的 gold set 上跑出可解释失败标签。
+ingestion、chunking、lexical retrieval、候选聚合与 evidence-pack 契约已在 `srd_35` 上就位。下一步是闭合 Phase 1：带 grounding 约束的 answer generation、claim / segment 级别的 citation 渲染、abstain 行为，并在 `evals/phase1_gold.yaml` 上跑出第一次评测结果。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -23,12 +23,18 @@
 - [x] Implement ingestion pipeline (extraction + normalization) — `scripts/ingest_srd35/`
 - [x] Add fixture corpus + golden outputs + preview evidence standard — `tests/fixtures/`, `docs/standards/pr_evidence.md`
 - [x] Implement chunker — baseline section-passthrough strategy, `scripts/chunker/`, `tests/test_chunker.py`
-- [ ] Implement a lexical-first baseline retrieval pipeline (hard filters → normalization → BM25/FTS retrieval → evidence pack)
-- [ ] Add a thin retrieval-debug CLI / script for inspectable candidate output
+- [x] Implement a lexical-first baseline retrieval pipeline (hard filters → normalization → BM25/FTS retrieval → evidence pack) — `scripts/retrieval/` (PR #49)
+  - [x] Chunk-type prior in domain-aware scoring (PR #52)
+  - [x] Structure-metadata indexing in the chunk index (PR #61)
+  - [x] Section-aware candidate shaping layer keyed by `(document_id, section_root)` (PR #64)
+  - [x] Chunk-adjacency fields (`parent_chunk_id`, `previous_chunk_id`, `next_chunk_id`) propagated through `LexicalCandidate` and `search_chunk_index` (PRs #67, #69)
+  - [x] Recall-coverage tests expanded (PR #53)
+- [x] Add a thin retrieval-debug CLI / script for inspectable candidate output — `scripts/retrieve_debug.py` (PR #66)
+- [x] Evidence-pack contract for retrieval output (PR #66)
 - [ ] Implement answer generation with grounding constraint
 - [ ] Implement citation rendering
 - [ ] Implement abstention behavior
-- [ ] Run evaluation against the Phase 0 test set
+- [ ] Run evaluation against the Phase 0 test set (`evals/phase1_gold.yaml`)
 
 ## Phase 2 - Quality Improvements
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -29,12 +29,11 @@
   - [x] Section-aware candidate shaping layer keyed by `(document_id, section_root)` (PR #64)
   - [x] Chunk-adjacency fields (`parent_chunk_id`, `previous_chunk_id`, `next_chunk_id`) propagated through `LexicalCandidate` and `search_chunk_index` (PRs #67, #69)
   - [x] Recall-coverage tests expanded (PR #53)
-- [x] Add a thin retrieval-debug CLI / script for inspectable candidate output — `scripts/retrieve_debug.py` (PR #66)
-- [x] Evidence-pack contract for retrieval output (PR #66)
+- [x] Evidence-pack contract for retrieval output + retrieval-debug CLI — `scripts/retrieve_debug.py` (PR #66)
 - [ ] Implement answer generation with grounding constraint
 - [ ] Implement citation rendering
 - [ ] Implement abstention behavior
-- [ ] Run evaluation against the Phase 0 test set (`evals/phase1_gold.yaml`)
+- [ ] Run evaluation against the Phase 1 gold set (`evals/phase1_gold.yaml`)
 
 ## Phase 2 - Quality Improvements
 

--- a/docs/zh/roadmap.md
+++ b/docs/zh/roadmap.md
@@ -29,12 +29,11 @@
   - [x] 基于 `(document_id, section_root)` 的 section-aware 候选聚合层（PR #64）
   - [x] 将 chunk adjacency 字段（`parent_chunk_id`、`previous_chunk_id`、`next_chunk_id`）贯穿到 `LexicalCandidate` 与 `search_chunk_index`（PR #67、#69）
   - [x] 扩展 recall-coverage 回归测试（PR #53）
-- [x] 增加一个可调试的 retrieval CLI / script，用来检查候选输出 — `scripts/retrieve_debug.py`（PR #66）
-- [x] retrieval 输出的 evidence-pack 契约（PR #66）
+- [x] retrieval 输出的 evidence-pack 契约 + 调试用 retrieval CLI — `scripts/retrieve_debug.py`（PR #66）
 - [ ] 实现带 grounding 约束的 answer generation
 - [ ] 实现 citation 渲染
 - [ ] 实现 abstain 行为
-- [ ] 在 Phase 0 测试集（`evals/phase1_gold.yaml`）上跑评测
+- [ ] 在 Phase 1 gold set（`evals/phase1_gold.yaml`）上跑评测
 
 ## Phase 2 - 质量提升
 

--- a/docs/zh/roadmap.md
+++ b/docs/zh/roadmap.md
@@ -23,12 +23,18 @@
 - [x] 实现 ingestion pipeline（extraction + normalization）— `scripts/ingest_srd35/`
 - [x] 加入 fixture corpus + golden outputs + preview evidence 标准 — `tests/fixtures/`、`docs/standards/pr_evidence.md`
 - [x] 实现 chunker — baseline section-passthrough strategy，`scripts/chunker/`、`tests/test_chunker.py`
-- [ ] 实现 lexical-first baseline retrieval pipeline（hard filters → normalization → BM25/FTS retrieval → evidence pack）
-- [ ] 增加一个可调试的 retrieval CLI / script，用来检查候选输出
+- [x] 实现 lexical-first baseline retrieval pipeline（hard filters → normalization → BM25/FTS retrieval → evidence pack）— `scripts/retrieval/`（PR #49）
+  - [x] 领域感知打分中的 chunk-type prior（PR #52）
+  - [x] 在 chunk index 中索引 structure metadata（PR #61）
+  - [x] 基于 `(document_id, section_root)` 的 section-aware 候选聚合层（PR #64）
+  - [x] 将 chunk adjacency 字段（`parent_chunk_id`、`previous_chunk_id`、`next_chunk_id`）贯穿到 `LexicalCandidate` 与 `search_chunk_index`（PR #67、#69）
+  - [x] 扩展 recall-coverage 回归测试（PR #53）
+- [x] 增加一个可调试的 retrieval CLI / script，用来检查候选输出 — `scripts/retrieve_debug.py`（PR #66）
+- [x] retrieval 输出的 evidence-pack 契约（PR #66）
 - [ ] 实现带 grounding 约束的 answer generation
 - [ ] 实现 citation 渲染
 - [ ] 实现 abstain 行为
-- [ ] 在 Phase 0 测试集上跑评测
+- [ ] 在 Phase 0 测试集（`evals/phase1_gold.yaml`）上跑评测
 
 ## Phase 2 - 质量提升
 


### PR DESCRIPTION
## Summary

- Drop stale "early implementation" / "Phase 1 bootstrap path in progress" framing from the READMEs; core retrieval pipeline is now live.
- Mark lexical-first retrieval and the retrieval-debug CLI as done on the roadmap, with sub-bullets for the landed refinements (chunk-type prior, structure metadata indexing, section-aware candidate shaping, chunk-adjacency propagation, evidence-pack contract, recall-coverage expansion).
- Point the READMEs' "Next step" sections at the remaining Phase 1 work: answer generation, citation rendering, abstention, and the evaluation run against `evals/phase1_gold.yaml`.

## Changes

- `README.md` — rewrite "Project status" and "Next step"; add `evals/phase1_gold.yaml` to the planned document set.
- `README.zh.md` — mirror the EN status/next-step updates while keeping the condensed Chinese structure.
- `docs/roadmap.md` — check off the lexical-first retrieval baseline and debug CLI items; add completed sub-bullets (PRs #49, #52, #53, #61, #64, #66, #67, #69); reference `evals/phase1_gold.yaml` on the evaluation line.
- `docs/zh/roadmap.md` — parallel updates to mirror the EN roadmap bullet-for-bullet.

## Out of scope

This PR only updates status/progress language in the READMEs and roadmaps. Design docs (architecture, chunking/retrieval, citation, metadata contract, evaluation plan, etc.) are not touched here — those updates are queued for PR 2 of this docs refresh.

## Test plan

- [x] `python -m pytest tests/ -x --tb=short` — 184 passed, 1 xfailed (no regressions; doc-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)