### PR TITLE
feat(answer): minimal rule-based answer path with citations and abstain (closes #23)

### DIFF
--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -150,6 +150,19 @@ The Phase 1 implementation is lexical-first and domain-aware. The concrete pipel
 
 Semantic / vector retrieval is deferred to Phase 2 hybrid extension as described in `docs/chunking_retrieval_design.md`.
 
+### 4.6a Answer stage (rule-based, v1)
+
+The v1 answer stage is a rule-based excerpt composer layered on top of the retrieval evidence pack. It turns an `EvidencePack` into either a grounded answer (primary excerpt + up to two supporting excerpts with chunk-level citations) or an abstention — no prose is synthesized. This is a deliberate validation scaffold; an LLM-backed prose composer is planned as a v2 successor that will consume the same `EvidencePack` contract.
+
+- rule-based excerpt composer — segment text is always a chunk excerpt, never generated
+- strict-signal abstain gate — at least one of exact_phrase_hit, protected_phrase_hit, or section_path_hit must be present on the top item
+- up to three segments per answer — one primary plus at most two supporting (sibling-first, then a distinct-signal cross-section, with a fallback sibling in slot 2)
+- citation binder — assigns stable citation ids, dedupes when two segments share the same (chunk_id, excerpt)
+- two-flag CLI — `--json` emits the strict schema shape; `--json-debug` adds a top-level `debug` block (non-schema-valid) with the pipeline trace and per-selected-item signals
+- v1 validation scaffold — shares `build_answer(pack) → AnswerResult` with the planned v2 LLM composer
+
+Full design lives in `docs/plans/2026-04-23-issue-23-minimal-answer-path.md`.
+
 ### 4.7 Answer composition
 
 The answer composition layer turns retrieved evidence into a grounded response.

--- a/docs/zh/architecture_overview.md
+++ b/docs/zh/architecture_overview.md
@@ -148,6 +148,19 @@
 
 语义/向量检索推迟至 `docs/chunking_retrieval_design.md` 所述的第二阶段 hybrid 扩展。
 
+### 4.6a 答案阶段（基于规则，v1）
+
+v1 答案阶段是叠加在检索证据包之上的基于规则的摘要式组合器。它将 `EvidencePack` 转换为有据答案（主摘要 + 最多两段辅助摘要，每段附带分块级引用）或弃答——不生成任何合成散文。这是有意为之的验证脚手架；后续 v2 将以同一 `EvidencePack` 契约引入基于 LLM 的散文合成器。
+
+- 基于规则的摘要组合器——段落文本始终取自分块摘录，绝不生成
+- 严格信号弃答门——首位证据项必须命中 exact_phrase_hit、protected_phrase_hit 或 section_path_hit 中至少一项
+- 每条答案最多三段——一段主答 + 最多两段辅助（先同组兄弟，再取信号不同的跨章节项，槽位 2 回退为下一个兄弟）
+- 引用绑定器——分配稳定的 citation_id，并对共享 `(chunk_id, excerpt)` 的段落去重
+- 双开关 CLI——`--json` 输出严格 schema 形态；`--json-debug` 追加顶层 `debug` 块（非 schema 合规）携带流水线追踪与逐项 match_signals
+- v1 验证脚手架——与计划中的 v2 LLM 组合器共享 `build_answer(pack) → AnswerResult` 接口
+
+完整设计见 `docs/plans/2026-04-23-issue-23-minimal-answer-path.md`。
+
 ### 4.7 答案生成
 
 答案生成层将检索到的证据转换为有据可查的响应。

--- a/examples/answer_with_citations.example.json
+++ b/examples/answer_with_citations.example.json
@@ -1,71 +1,69 @@
 {
-  "query": "How many bonus feats does a Fighter receive, and when?",
+  "query": "attack of opportunity",
   "answer_type": "grounded",
   "answer_segments": [
     {
-      "segment_id": "claim_1",
-      "text": "A Fighter gains a bonus feat at 1st level, then another at 2nd level and every two Fighter levels thereafter.",
+      "segment_id": "seg_1",
+      "text": "You threaten all squares into which you can make a melee attack, even when it is not your turn. Generally, that means everything in all squares adjacent to your space.",
       "support_type": "direct_support",
-      "citation_ids": ["cit_1"]
+      "citation_ids": [
+        "cit_1"
+      ]
     },
     {
-      "segment_id": "claim_2",
-      "text": "Those bonus feats must come from the fighter bonus feat list, and the character still has to meet the prerequisites.",
+      "segment_id": "seg_2",
+      "text": "Sometimes a combatant in a melee lets her guard down or takes a reckless action. In this case, combatants near her can take advantage of her lapse in defense to attack her for free. These free attacks are called attacks of opportunity.",
       "support_type": "direct_support",
-      "citation_ids": ["cit_2"]
+      "citation_ids": [
+        "cit_2"
+      ]
     }
   ],
   "citations": [
     {
       "citation_id": "cit_1",
-      "chunk_id": "srd_35::classes::fighter::bonus_feats::chunk_1",
+      "chunk_id": "srd_35::combat::attack_of_opportunity::chunk_2",
       "source_ref": {
-        "source_id": "srd_35",
-        "title": "System Reference Document",
+        "authority_level": "official_reference",
         "edition": "3.5e",
+        "source_id": "srd_35",
         "source_type": "srd",
-        "authority_level": "official_reference"
+        "title": "System Reference Document"
       },
       "locator": {
+        "entry_title": "Threatened Squares",
         "section_path": [
-          "Classes",
-          "Fighter",
-          "Class Features",
-          "Bonus Feats"
+          "Combat",
+          "Attack of Opportunity",
+          "Threatened Squares"
         ],
-        "entry_title": "Bonus Feats",
-        "source_location": "ClassesI.rtf > Bonus Feats > paragraph 1"
+        "source_location": "Combat.rtf > Threatened Squares"
       },
-      "excerpt": "At 1st level, a fighter gets a bonus combat-oriented feat. The fighter gains an additional bonus feat at 2nd level and every two fighter levels thereafter."
+      "excerpt": "You threaten all squares into which you can make a melee attack, even when it is not your turn. Generally, that means everything in all squares adjacent to your space."
     },
     {
       "citation_id": "cit_2",
-      "chunk_id": "srd_35::classes::fighter::bonus_feats::chunk_1",
+      "chunk_id": "srd_35::combat::attack_of_opportunity::chunk_1",
       "source_ref": {
-        "source_id": "srd_35",
-        "title": "System Reference Document",
+        "authority_level": "official_reference",
         "edition": "3.5e",
+        "source_id": "srd_35",
         "source_type": "srd",
-        "authority_level": "official_reference"
+        "title": "System Reference Document"
       },
       "locator": {
+        "entry_title": "Attack of Opportunity",
         "section_path": [
-          "Classes",
-          "Fighter",
-          "Class Features",
-          "Bonus Feats"
+          "Combat",
+          "Attack of Opportunity"
         ],
-        "entry_title": "Bonus Feats",
-        "source_location": "ClassesI.rtf > Bonus Feats > paragraph 2"
+        "source_location": "Combat.rtf > Attack of Opportunity > paragraph 1"
       },
-      "excerpt": "These bonus feats must be drawn from the feats noted as fighter bonus feats. A fighter must still meet all prerequisites for a bonus feat."
+      "excerpt": "Sometimes a combatant in a melee lets her guard down or takes a reckless action. In this case, combatants near her can take advantage of her lapse in defense to attack her for free. These free attacks are called attacks of opportunity."
     }
   ],
   "retrieval_metadata": {
-    "candidate_chunks": 5,
-    "selected_chunks": 1,
-    "embedding_model": "nomic-embed-text-v1.5",
-    "answer_model": "claude-sonnet-4-6",
-    "reranker_model": null
+    "candidate_chunks": 2,
+    "selected_chunks": 2
   }
 }

--- a/examples/evidence_pack.example.json
+++ b/examples/evidence_pack.example.json
@@ -1,0 +1,105 @@
+{
+  "query": {
+    "raw": "attack of opportunity",
+    "normalized": "attack of opportunity",
+    "tokens": [
+      "attack of opportunity"
+    ],
+    "protected_phrases": [
+      "attack of opportunity"
+    ],
+    "aliases_applied": []
+  },
+  "constraints": {
+    "editions": [
+      "3.5e"
+    ],
+    "source_types": [
+      "srd"
+    ],
+    "authority_levels": [
+      "official_reference"
+    ],
+    "excluded_source_ids": []
+  },
+  "trace": {
+    "total_candidates": 2,
+    "group_count": 1,
+    "groups": [
+      {
+        "document_id": "srd_35::combat",
+        "section_root": "Combat",
+        "candidate_count": 2
+      }
+    ]
+  },
+  "evidence": [
+    {
+      "rank": 1,
+      "chunk_id": "srd_35::combat::attack_of_opportunity::chunk_2",
+      "document_id": "srd_35::combat",
+      "chunk_type": "rule_section",
+      "section_root": "Combat",
+      "source_ref": {
+        "authority_level": "official_reference",
+        "edition": "3.5e",
+        "source_id": "srd_35",
+        "source_type": "srd",
+        "title": "System Reference Document"
+      },
+      "locator": {
+        "entry_title": "Threatened Squares",
+        "section_path": [
+          "Combat",
+          "Attack of Opportunity",
+          "Threatened Squares"
+        ],
+        "source_location": "Combat.rtf > Threatened Squares"
+      },
+      "match_signals": {
+        "exact_phrase_hits": [
+          "attack of opportunity"
+        ],
+        "protected_phrase_hits": [
+          "attack of opportunity"
+        ],
+        "section_path_hit": true,
+        "token_overlap_count": 3
+      },
+      "content": "You threaten all squares into which you can make a melee attack, even when it is not your turn. Generally, that means everything in all squares adjacent to your space."
+    },
+    {
+      "rank": 2,
+      "chunk_id": "srd_35::combat::attack_of_opportunity::chunk_1",
+      "document_id": "srd_35::combat",
+      "chunk_type": "rule_section",
+      "section_root": "Combat",
+      "source_ref": {
+        "authority_level": "official_reference",
+        "edition": "3.5e",
+        "source_id": "srd_35",
+        "source_type": "srd",
+        "title": "System Reference Document"
+      },
+      "locator": {
+        "entry_title": "Attack of Opportunity",
+        "section_path": [
+          "Combat",
+          "Attack of Opportunity"
+        ],
+        "source_location": "Combat.rtf > Attack of Opportunity > paragraph 1"
+      },
+      "match_signals": {
+        "exact_phrase_hits": [
+          "attack of opportunity"
+        ],
+        "protected_phrase_hits": [
+          "attack of opportunity"
+        ],
+        "section_path_hit": true,
+        "token_overlap_count": 3
+      },
+      "content": "Sometimes a combatant in a melee lets her guard down or takes a reckless action. In this case, combatants near her can take advantage of her lapse in defense to attack her for free. These free attacks are called attacks of opportunity."
+    }
+  ]
+}

--- a/scripts/answer/__init__.py
+++ b/scripts/answer/__init__.py
@@ -1,0 +1,28 @@
+"""Rule-based answer stage: EvidencePack → AnswerResult."""
+from __future__ import annotations
+
+from .citation_binder import bind_citations
+from .composer import compose_segments
+from .contracts import (
+    Abstention,
+    AnswerResult,
+    AnswerSegment,
+    AssessmentResult,
+    Citation,
+    GroundedAnswer,
+)
+from .pipeline import build_answer
+from .support_assessor import assess_support
+
+__all__ = [
+    "Abstention",
+    "AnswerResult",
+    "AnswerSegment",
+    "AssessmentResult",
+    "Citation",
+    "GroundedAnswer",
+    "assess_support",
+    "bind_citations",
+    "build_answer",
+    "compose_segments",
+]

--- a/scripts/answer/citation_binder.py
+++ b/scripts/answer/citation_binder.py
@@ -1,0 +1,50 @@
+"""Citation binder: assigns citation ids and builds Citation records.
+
+Implements §3.4 of the minimal-answer-path design. Deduplicates by the
+``(chunk_id, excerpt)`` tuple so two segments quoting the same chunk with
+the same excerpt share one ``citation_id``.
+"""
+from __future__ import annotations
+
+from scripts.retrieval.evidence_pack import EvidencePack
+
+from .composer import _ComposedSegment
+from .contracts import AnswerSegment, Citation
+
+
+def bind_citations(
+    composed_segments: tuple[_ComposedSegment, ...],
+    pack: EvidencePack,  # noqa: ARG001 — reserved for locator narrowing (policy §5)
+) -> tuple[tuple[AnswerSegment, ...], tuple[Citation, ...]]:
+    """Attach stable citation ids to segments and build the citations tuple."""
+    citations: list[Citation] = []
+    citation_ids_by_key: dict[tuple[str, str], str] = {}
+    answer_segments: list[AnswerSegment] = []
+
+    for composed in composed_segments:
+        item = composed.evidence_item
+        key = (item.chunk_id, composed.text)
+        citation_id = citation_ids_by_key.get(key)
+        if citation_id is None:
+            citation_id = f"cit_{len(citations) + 1}"
+            citation_ids_by_key[key] = citation_id
+            citations.append(
+                Citation(
+                    citation_id=citation_id,
+                    chunk_id=item.chunk_id,
+                    source_ref=item.source_ref,
+                    locator=item.locator,
+                    excerpt=composed.text,
+                )
+            )
+
+        answer_segments.append(
+            AnswerSegment(
+                segment_id=composed.segment_id,
+                text=composed.text,
+                support_type=composed.support_type,
+                citation_ids=(citation_id,),
+            )
+        )
+
+    return tuple(answer_segments), tuple(citations)

--- a/scripts/answer/composer.py
+++ b/scripts/answer/composer.py
@@ -1,0 +1,134 @@
+"""Answer composer: builds 1-3 segments per §3.3 of the minimal-answer-path design.
+
+Emits a primary segment (the top evidence item) plus up to two supporting
+segments drawn from siblings in the same ``(document_id, section_root)`` group
+and a distinct-signal cross-section fallback. All segment text is a chunk
+excerpt; the composer never synthesizes prose.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Literal
+
+from scripts.retrieval.evidence_pack import EvidenceItem, EvidencePack
+
+
+_EXCERPT_MAX_LEN = 500
+
+
+@dataclass(frozen=True)
+class _ComposedSegment:
+    """Internal composer output carrying enough context for the binder and CLI."""
+
+    segment_id: str
+    text: str
+    support_type: Literal["direct_support", "supported_inference"]
+    evidence_item: EvidenceItem
+    role: Literal["primary", "sibling", "cross-section"]
+
+
+def compose_segments(pack: EvidencePack) -> tuple[_ComposedSegment, ...]:
+    """Compose 1-3 excerpt-based segments from the pack's evidence."""
+    primary = pack.evidence[0]
+    segments: list[_ComposedSegment] = [
+        _build_segment("seg_1", primary, role="primary"),
+    ]
+
+    siblings = list(_iter_siblings(pack, primary))
+    used_sibling_ids: set[str] = set()
+
+    # Slot 1: first sibling in rank order.
+    if siblings:
+        slot1 = siblings[0]
+        used_sibling_ids.add(slot1.chunk_id)
+        segments.append(_build_segment("seg_2", slot1, role="sibling"))
+
+    # Slot 2: distinct-signal cross-section, else fallback sibling.
+    slot2_item, slot2_role = _select_slot2(pack, primary, siblings, used_sibling_ids)
+    if slot2_item is not None:
+        segment_id = f"seg_{len(segments) + 1}"
+        segments.append(_build_segment(segment_id, slot2_item, role=slot2_role))
+
+    return tuple(segments)
+
+
+def _build_segment(
+    segment_id: str,
+    item: EvidenceItem,
+    *,
+    role: Literal["primary", "sibling", "cross-section"],
+) -> _ComposedSegment:
+    return _ComposedSegment(
+        segment_id=segment_id,
+        text=_truncate(item.content),
+        support_type=_classify_support(item),
+        evidence_item=item,
+        role=role,
+    )
+
+
+def _truncate(content: str) -> str:
+    if len(content) <= _EXCERPT_MAX_LEN:
+        return content
+    return content[:_EXCERPT_MAX_LEN].rstrip() + "…"
+
+
+def _classify_support(item: EvidenceItem) -> Literal["direct_support", "supported_inference"]:
+    signals = item.match_signals
+    if signals["exact_phrase_hits"] or signals["protected_phrase_hits"]:
+        return "direct_support"
+    return "supported_inference"
+
+
+def _iter_siblings(pack: EvidencePack, primary: EvidenceItem) -> Iterator[EvidenceItem]:
+    """Yield siblings (same document_id + section_root) excluding the primary, by rank."""
+    for item in pack.evidence:
+        if item.chunk_id == primary.chunk_id:
+            continue
+        if item.document_id == primary.document_id and item.section_root == primary.section_root:
+            yield item
+
+
+def _select_slot2(
+    pack: EvidencePack,
+    primary: EvidenceItem,
+    siblings: list[EvidenceItem],
+    used_sibling_ids: set[str],
+) -> tuple[EvidenceItem | None, Literal["sibling", "cross-section"]]:
+    """Pick the slot-2 item: distinct-signal cross-section, else fallback sibling."""
+    cross_section = _find_cross_section(pack, primary)
+    if cross_section is not None:
+        return cross_section, "cross-section"
+
+    for sibling in siblings:
+        if sibling.chunk_id not in used_sibling_ids:
+            return sibling, "sibling"
+
+    return None, "sibling"
+
+
+def _find_cross_section(pack: EvidencePack, primary: EvidenceItem) -> EvidenceItem | None:
+    """Return the lowest-rank cross-section item whose hit set is NOT a subset of primary's.
+
+    Distinctness comparison is limited to ``exact_phrase_hits`` and
+    ``protected_phrase_hits`` only (spec §3.3); ``section_path_hit`` is
+    excluded because the section-root grouping already handles it.
+    """
+    primary_hits = _phrase_hit_set(primary)
+    best: EvidenceItem | None = None
+    for item in pack.evidence:
+        if item.chunk_id == primary.chunk_id:
+            continue
+        if item.section_root == primary.section_root:
+            continue
+        candidate_hits = _phrase_hit_set(item)
+        if candidate_hits.issubset(primary_hits):
+            continue
+        if best is None or item.rank < best.rank:
+            best = item
+    return best
+
+
+def _phrase_hit_set(item: EvidenceItem) -> set[str]:
+    signals = item.match_signals
+    return set(signals["exact_phrase_hits"]) | set(signals["protected_phrase_hits"])

--- a/scripts/answer/contracts.py
+++ b/scripts/answer/contracts.py
@@ -1,0 +1,61 @@
+"""Contracts for the rule-based answer stage.
+
+Defines the frozen dataclasses produced and consumed by the answer pipeline:
+``AssessmentResult`` from the support assessor, ``AnswerSegment`` and
+``Citation`` from the composer/binder, and the ``AnswerResult`` union
+(``GroundedAnswer`` or ``Abstention``) returned by ``build_answer``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class AnswerSegment:
+    """An ordered answer segment with its support type and citation ids."""
+
+    segment_id: str
+    text: str
+    support_type: Literal["direct_support", "supported_inference"]
+    citation_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Citation:
+    """A chunk-level citation referenced by one or more segments."""
+
+    citation_id: str
+    chunk_id: str
+    source_ref: dict[str, Any]
+    locator: dict[str, Any]
+    excerpt: str
+
+
+@dataclass(frozen=True)
+class GroundedAnswer:
+    """A grounded answer: one primary plus up to two supporting segments."""
+
+    query: str
+    segments: tuple[AnswerSegment, ...]
+    citations: tuple[Citation, ...]
+
+
+@dataclass(frozen=True)
+class Abstention:
+    """An abstention with a canned human-readable reason and a trigger code."""
+
+    query: str
+    reason: str
+    trigger_code: Literal["empty_evidence", "weak_signals"]
+
+
+AnswerResult = GroundedAnswer | Abstention
+
+
+@dataclass(frozen=True)
+class AssessmentResult:
+    """Outcome of the support assessor."""
+
+    outcome: Literal["grounded", "abstain"]
+    trigger_code: Literal["empty_evidence", "weak_signals"] | None

--- a/scripts/answer/pipeline.py
+++ b/scripts/answer/pipeline.py
@@ -1,0 +1,135 @@
+"""Answer pipeline orchestration and JSON serialization helpers.
+
+``build_answer`` wires the assessor, composer, and citation binder into one
+call that turns an ``EvidencePack`` into an ``AnswerResult``. The two
+``to_*_json`` helpers are shared between the CLI and the tests so the
+strict schema shape and the extended debug shape live in one place.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.retrieval.evidence_pack import EvidencePack
+
+from .citation_binder import bind_citations
+from .composer import _ComposedSegment, compose_segments
+from .contracts import Abstention, AnswerResult, GroundedAnswer
+from .support_assessor import assess_support
+
+
+_ABSTAIN_REASONS: dict[str, str] = {
+    "empty_evidence": "Insufficient evidence: no chunks retrieved for this query.",
+    "weak_signals": "Insufficient evidence: retrieved chunks do not clearly match the query.",
+}
+
+
+def build_answer(pack: EvidencePack) -> AnswerResult:
+    """Run the assessor → composer → binder pipeline against the pack."""
+    assessment = assess_support(pack)
+    query_text = pack.query.raw_query
+
+    if assessment.outcome == "abstain":
+        trigger = assessment.trigger_code
+        assert trigger is not None  # invariant: abstain always has a trigger
+        return Abstention(
+            query=query_text,
+            reason=_ABSTAIN_REASONS[trigger],
+            trigger_code=trigger,
+        )
+
+    composed = compose_segments(pack)
+    segments, citations = bind_citations(composed, pack)
+    return GroundedAnswer(
+        query=query_text,
+        segments=segments,
+        citations=citations,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization (shared by CLI and tests)
+# ---------------------------------------------------------------------------
+
+
+def to_strict_json(result: AnswerResult, pack: EvidencePack) -> dict[str, Any]:
+    """Serialize an ``AnswerResult`` to the strict schema shape (``--json``)."""
+    if isinstance(result, Abstention):
+        return {
+            "query": result.query,
+            "answer_type": "abstain",
+            "abstention_reason": result.reason,
+        }
+
+    citations_payload = [
+        {
+            "citation_id": c.citation_id,
+            "chunk_id": c.chunk_id,
+            "source_ref": c.source_ref,
+            "locator": c.locator,
+            "excerpt": c.excerpt,
+        }
+        for c in result.citations
+    ]
+    selected_chunks = len({c.chunk_id for c in result.citations})
+
+    return {
+        "query": result.query,
+        "answer_type": "grounded",
+        "answer_segments": [
+            {
+                "segment_id": s.segment_id,
+                "text": s.text,
+                "support_type": s.support_type,
+                "citation_ids": list(s.citation_ids),
+            }
+            for s in result.segments
+        ],
+        "citations": citations_payload,
+        "retrieval_metadata": {
+            "candidate_chunks": pack.trace.total_candidates,
+            "selected_chunks": selected_chunks,
+        },
+    }
+
+
+def to_debug_json(
+    result: AnswerResult,
+    pack: EvidencePack,
+    composed_segments: tuple[_ComposedSegment, ...],
+) -> dict[str, Any]:
+    """Serialize to the extended ``--json-debug`` shape (non-schema-valid)."""
+    payload = to_strict_json(result, pack)
+
+    abstention_code: str | None = None
+    selected_items: list[dict[str, Any]] = []
+    if isinstance(result, Abstention):
+        abstention_code = result.trigger_code
+    else:
+        for composed in composed_segments:
+            item = composed.evidence_item
+            selected_items.append(
+                {
+                    "chunk_id": item.chunk_id,
+                    "rank": item.rank,
+                    "match_signals": dict(item.match_signals),
+                    "role": composed.role,
+                }
+            )
+
+    payload["debug"] = {
+        "abstention_code": abstention_code,
+        "pipeline_trace": {
+            "total_candidates": pack.trace.total_candidates,
+            "group_count": pack.trace.group_count,
+            "groups": [
+                {
+                    "document_id": gs.document_id,
+                    "section_root": gs.section_root,
+                    "candidate_count": gs.candidate_count,
+                }
+                for gs in pack.trace.group_summaries
+            ],
+        },
+        "selected_items": selected_items,
+    }
+    return payload

--- a/scripts/answer/support_assessor.py
+++ b/scripts/answer/support_assessor.py
@@ -1,0 +1,30 @@
+"""Support assessor: strict-signal abstain gate.
+
+Implements §3.2 of the minimal-answer-path design. The assessor inspects the
+top evidence item in the pack and decides whether the answer pipeline should
+produce a grounded answer or abstain. ``token_overlap_count`` alone does not
+license a grounded answer; at least one of ``exact_phrase_hits``,
+``protected_phrase_hits``, or ``section_path_hit`` must be present.
+"""
+from __future__ import annotations
+
+from scripts.retrieval.evidence_pack import EvidencePack
+
+from .contracts import AssessmentResult
+
+
+def assess_support(pack: EvidencePack) -> AssessmentResult:
+    """Decide whether the pack's top item has strong enough signals to answer."""
+    if not pack.evidence:
+        return AssessmentResult(outcome="abstain", trigger_code="empty_evidence")
+
+    signals = pack.evidence[0].match_signals
+    has_strong_signal = (
+        bool(signals["exact_phrase_hits"])
+        or bool(signals["protected_phrase_hits"])
+        or signals["section_path_hit"]
+    )
+    if not has_strong_signal:
+        return AssessmentResult(outcome="abstain", trigger_code="weak_signals")
+
+    return AssessmentResult(outcome="grounded", trigger_code=None)

--- a/scripts/answer_question.py
+++ b/scripts/answer_question.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Answer a query from the local chunk index with citations or abstain.
+
+Usage:
+    python scripts/answer_question.py "attack of opportunity"
+    python scripts/answer_question.py "turn undead" --top-k 5
+    python scripts/answer_question.py "fighter bonus feats" --json
+    python scripts/answer_question.py "fighter bonus feats" --json-debug
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+# Allow running from repo root without PYTHONPATH.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.answer.composer import compose_segments
+from scripts.answer.contracts import Abstention, GroundedAnswer
+from scripts.answer.pipeline import build_answer, to_debug_json, to_strict_json
+from scripts.answer.support_assessor import assess_support
+from scripts.retrieval.evidence_pack import EvidencePack, retrieve_evidence
+
+
+def _print_query_block(pack: EvidencePack) -> None:
+    q = pack.query
+    print("=" * 72)
+    print("QUERY")
+    print("=" * 72)
+    print(f"  Raw:        {q.raw_query}")
+    print(f"  Normalized: {q.normalized_text}")
+
+
+def _print_grounded_text(result: GroundedAnswer, pack: EvidencePack) -> None:
+    print()
+    print("=" * 72)
+    print(f"ANSWER ({len(result.segments)} segment(s))")
+    print("=" * 72)
+    for segment in result.segments:
+        markers = " ".join(f"[{cid}]" for cid in segment.citation_ids)
+        print(f"\n[{segment.segment_id}] ({segment.support_type}) {markers}")
+        for line in textwrap.wrap(segment.text, width=78):
+            print(f"  {line}")
+
+    print()
+    print("=" * 72)
+    print(f"CITATIONS ({len(result.citations)})")
+    print("=" * 72)
+    for citation in result.citations:
+        locator = _fmt_locator(citation.locator)
+        preview = textwrap.shorten(citation.excerpt, width=140, placeholder="…")
+        title = citation.source_ref.get("title", "?")
+        print(f"\n  [{citation.citation_id}] {title}")
+        print(f"    chunk:   {citation.chunk_id}")
+        print(f"    locator: {locator}")
+        print(f"    excerpt: {preview}")
+
+    print()
+    print("=" * 72)
+    print("PIPELINE TRACE")
+    print("=" * 72)
+    t = pack.trace
+    print(f"  Candidates entering shaping: {t.total_candidates}")
+    print(f"  Groups formed:               {t.group_count}")
+    for gs in t.group_summaries:
+        print(f"    [{gs.document_id} / {gs.section_root}] {gs.candidate_count} items")
+
+
+def _print_abstain_text(result: Abstention) -> None:
+    print()
+    print("=" * 72)
+    print("ABSTAIN")
+    print("=" * 72)
+    print(f"  Trigger: {result.trigger_code}")
+    print(f"  Reason:  {result.reason}")
+
+
+def _fmt_locator(locator: dict) -> str:
+    parts: list[str] = []
+    if sp := locator.get("section_path"):
+        parts.append(" > ".join(sp))
+    if sl := locator.get("source_location"):
+        parts.append(sl)
+    return " | ".join(parts) if parts else str(locator)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Answer a query from the local chunk index with citations or abstain.",
+    )
+    parser.add_argument("query", help="The query string to answer")
+    parser.add_argument(
+        "--top-k", type=int, default=10, help="Number of candidates (default: 10)"
+    )
+    parser.add_argument(
+        "--db", type=str, default=None, help="Path to lexical.db (default: auto)"
+    )
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit strict schema JSON (answer_with_citations.schema.json).",
+    )
+    output_group.add_argument(
+        "--json-debug",
+        action="store_true",
+        dest="json_debug",
+        help="Emit extended JSON with a top-level `debug` key (non-schema-valid).",
+    )
+    args = parser.parse_args()
+
+    db_path = Path(args.db) if args.db else None
+    effective_db = db_path or (REPO_ROOT / "data" / "index" / "srd_35" / "lexical.db")
+    if not effective_db.exists():
+        print(
+            f"Error: chunk index not found at {effective_db}\n"
+            "Build the lexical index first:\n"
+            "  python scripts/chunk_srd_35.py",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    pack = retrieve_evidence(args.query, db_path=db_path, top_k=args.top_k)
+    result = build_answer(pack)
+
+    if args.json_output:
+        print(json.dumps(to_strict_json(result, pack), indent=2, ensure_ascii=False))
+        return
+
+    if args.json_debug:
+        # Re-run assessor + composer to get the composed segments for debug serialization.
+        # build_answer's internal composed tuple isn't exposed; recomposing is cheap and
+        # deterministic over the same pack.
+        composed: tuple = ()
+        if isinstance(result, GroundedAnswer):
+            assessment = assess_support(pack)
+            if assessment.outcome == "grounded":
+                composed = compose_segments(pack)
+        print(json.dumps(to_debug_json(result, pack, composed), indent=2, ensure_ascii=False))
+        return
+
+    _print_query_block(pack)
+    if isinstance(result, Abstention):
+        _print_abstain_text(result)
+    else:
+        _print_grounded_text(result, pack)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regen_examples.py
+++ b/scripts/regen_examples.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Regenerate example artifacts for the evidence pack and answer contracts.
+
+Builds a tiny temporary chunk index in-memory, runs the real retrieval and
+answer pipelines against it, and overwrites:
+
+    examples/evidence_pack.example.json
+    examples/answer_with_citations.example.json
+
+Usage:
+    python scripts/regen_examples.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.answer.pipeline import build_answer, to_strict_json
+from scripts.retrieval.evidence_pack import retrieve_evidence
+from scripts.retrieval.lexical_index import build_chunk_index
+from scripts.retrieve_debug import _to_json as pack_to_json
+
+
+_EXAMPLES_DIR = REPO_ROOT / "examples"
+
+
+_CHUNKS: list[dict] = [
+    {
+        "chunk_id": "srd_35::combat::attack_of_opportunity::chunk_1",
+        "document_id": "srd_35::combat",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "entry_title": "Attack of Opportunity",
+            "source_location": "Combat.rtf > Attack of Opportunity > paragraph 1",
+        },
+        "chunk_type": "rule_section",
+        "content": (
+            "Sometimes a combatant in a melee lets her guard down or "
+            "takes a reckless action. In this case, combatants near her "
+            "can take advantage of her lapse in defense to attack her "
+            "for free. These free attacks are called attacks of "
+            "opportunity."
+        ),
+    },
+    {
+        "chunk_id": "srd_35::combat::attack_of_opportunity::chunk_2",
+        "document_id": "srd_35::combat",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity", "Threatened Squares"],
+            "entry_title": "Threatened Squares",
+            "source_location": "Combat.rtf > Threatened Squares",
+        },
+        "chunk_type": "rule_section",
+        "content": (
+            "You threaten all squares into which you can make a melee "
+            "attack, even when it is not your turn. Generally, that "
+            "means everything in all squares adjacent to your space."
+        ),
+    },
+    {
+        "chunk_id": "srd_35::spells::fireball::chunk_1",
+        "document_id": "srd_35::spells",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Spells", "Fireball"],
+            "entry_title": "Fireball",
+            "source_location": "SpellsD-F.rtf > Fireball",
+        },
+        "chunk_type": "rule_section",
+        "content": (
+            "A fireball spell generates a searing explosion of flame "
+            "that detonates with a low roar. It deals 1d6 points of "
+            "fire damage per caster level."
+        ),
+    },
+]
+
+
+def _write_pack_example(pack, out_path: Path) -> None:
+    payload = pack_to_json(pack)
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_answer_example(result, pack, out_path: Path) -> None:
+    payload = to_strict_json(result, pack)
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    _EXAMPLES_DIR.mkdir(parents=True, exist_ok=True)
+
+    # ignore_cleanup_errors: on Windows the SQLite file handle may linger briefly
+    # after the sqlite3 module's context manager exits, causing TemporaryDirectory
+    # cleanup to race. The example content is already written by then.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_str:
+        tmp_dir = Path(tmp_str)
+        chunk_paths: list[Path] = []
+        for chunk in _CHUNKS:
+            chunk_path = tmp_dir / f"{chunk['chunk_id'].replace('::', '__')}.json"
+            chunk_path.write_text(
+                json.dumps(chunk, ensure_ascii=False), encoding="utf-8"
+            )
+            chunk_paths.append(chunk_path)
+        db_path = tmp_dir / "lexical.db"
+        build_chunk_index(db_path, chunk_paths)
+
+        pack = retrieve_evidence(
+            "attack of opportunity", db_path=db_path, top_k=10
+        )
+        result = build_answer(pack)
+
+    pack_out = _EXAMPLES_DIR / "evidence_pack.example.json"
+    answer_out = _EXAMPLES_DIR / "answer_with_citations.example.json"
+    _write_pack_example(pack, pack_out)
+    _write_answer_example(result, pack, answer_out)
+
+    print(f"wrote {pack_out}")
+    print(f"wrote {answer_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_answer_citation_binder.py
+++ b/tests/test_answer_citation_binder.py
@@ -1,0 +1,150 @@
+"""Tests for the citation binder (§3.4)."""
+from __future__ import annotations
+
+from scripts.answer.citation_binder import bind_citations
+from scripts.answer.composer import _ComposedSegment
+from scripts.retrieval.contracts import MatchSignals, NormalizedQuery
+from scripts.retrieval.evidence_pack import (
+    EvidenceItem,
+    EvidencePack,
+    PipelineTrace,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_SOURCE_REF = {
+    "source_id": "srd_35",
+    "title": "System Reference Document",
+    "edition": "3.5e",
+    "source_type": "srd",
+    "authority_level": "official_reference",
+}
+
+
+def _make_query() -> NormalizedQuery:
+    return NormalizedQuery(
+        raw_query="q",
+        normalized_text="q",
+        tokens=["q"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+
+
+def _empty_signals() -> MatchSignals:
+    return {
+        "exact_phrase_hits": [],
+        "protected_phrase_hits": [],
+        "section_path_hit": True,
+        "token_overlap_count": 0,
+    }
+
+
+def _make_item(
+    chunk_id: str,
+    *,
+    content: str,
+    rank: int = 1,
+    locator: dict | None = None,
+) -> EvidenceItem:
+    return EvidenceItem(
+        chunk_id=chunk_id,
+        document_id="doc::main",
+        rank=rank,
+        content=content,
+        chunk_type="rule_section",
+        source_ref=_SOURCE_REF,
+        locator=locator or {"section_path": ["Combat"], "source_location": "test"},
+        match_signals=_empty_signals(),
+        section_root="Combat",
+    )
+
+
+def _make_composed(
+    segment_id: str,
+    item: EvidenceItem,
+    *,
+    text: str | None = None,
+    role: str = "primary",
+) -> _ComposedSegment:
+    return _ComposedSegment(
+        segment_id=segment_id,
+        text=text if text is not None else item.content,
+        support_type="direct_support",
+        evidence_item=item,
+        role=role,  # type: ignore[arg-type]
+    )
+
+
+def _make_pack() -> EvidencePack:
+    return EvidencePack(
+        query=_make_query(),
+        constraints_summary={},
+        evidence=(),
+        trace=PipelineTrace(total_candidates=0, group_count=0, group_summaries=()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_segment_single_citation():
+    item = _make_item("chunk::a", content="alpha")
+    composed = (_make_composed("seg_1", item),)
+    segments, citations = bind_citations(composed, _make_pack())
+
+    assert len(segments) == 1
+    assert len(citations) == 1
+    assert citations[0].citation_id == "cit_1"
+    assert segments[0].citation_ids == ("cit_1",)
+
+
+def test_three_segments_different_chunks_three_citations():
+    items = [_make_item(f"chunk::{i}", content=f"text-{i}") for i in range(3)]
+    composed = tuple(
+        _make_composed(f"seg_{i + 1}", item) for i, item in enumerate(items)
+    )
+    segments, citations = bind_citations(composed, _make_pack())
+
+    assert [c.citation_id for c in citations] == ["cit_1", "cit_2", "cit_3"]
+    assert [s.citation_ids for s in segments] == [
+        ("cit_1",),
+        ("cit_2",),
+        ("cit_3",),
+    ]
+
+
+def test_duplicate_chunk_and_excerpt_shares_citation():
+    item = _make_item("chunk::shared", content="same text")
+    composed = (
+        _make_composed("seg_1", item),
+        _make_composed("seg_2", item),
+    )
+    segments, citations = bind_citations(composed, _make_pack())
+
+    assert len(citations) == 1
+    assert citations[0].citation_id == "cit_1"
+    assert segments[0].citation_ids == ("cit_1",)
+    assert segments[1].citation_ids == ("cit_1",)
+
+
+def test_citation_excerpt_equals_segment_text():
+    item = _make_item("chunk::a", content="full content")
+    composed = (_make_composed("seg_1", item, text="excerpt text"),)
+    _, citations = bind_citations(composed, _make_pack())
+    assert citations[0].excerpt == "excerpt text"
+
+
+def test_citation_carries_source_ref_and_locator():
+    locator = {"section_path": ["Magic"], "source_location": "Spells.rtf#42"}
+    item = _make_item("chunk::z", content="c", locator=locator)
+    composed = (_make_composed("seg_1", item),)
+    _, citations = bind_citations(composed, _make_pack())
+    assert citations[0].source_ref == _SOURCE_REF
+    assert citations[0].locator == locator

--- a/tests/test_answer_composer.py
+++ b/tests/test_answer_composer.py
@@ -1,0 +1,257 @@
+"""Tests for the answer composer (§3.3)."""
+from __future__ import annotations
+
+from scripts.answer.composer import compose_segments
+from scripts.retrieval.contracts import MatchSignals, NormalizedQuery
+from scripts.retrieval.evidence_pack import (
+    EvidenceItem,
+    EvidencePack,
+    PipelineTrace,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_query() -> NormalizedQuery:
+    return NormalizedQuery(
+        raw_query="q",
+        normalized_text="q",
+        tokens=["q"],
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+
+
+def _make_signals(
+    *,
+    exact: list[str] | None = None,
+    protected: list[str] | None = None,
+    section_path_hit: bool = False,
+    token_overlap_count: int = 0,
+) -> MatchSignals:
+    return {
+        "exact_phrase_hits": list(exact or []),
+        "protected_phrase_hits": list(protected or []),
+        "section_path_hit": section_path_hit,
+        "token_overlap_count": token_overlap_count,
+    }
+
+
+def _make_item(
+    chunk_id: str,
+    *,
+    rank: int,
+    document_id: str = "doc::main",
+    section_root: str = "Combat",
+    content: str = "Rule text.",
+    signals: MatchSignals | None = None,
+) -> EvidenceItem:
+    return EvidenceItem(
+        chunk_id=chunk_id,
+        document_id=document_id,
+        rank=rank,
+        content=content,
+        chunk_type="rule_section",
+        source_ref={
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        locator={"section_path": [section_root], "source_location": "test"},
+        match_signals=signals or _make_signals(exact=["q"]),
+        section_root=section_root,
+    )
+
+
+def _make_pack(items: list[EvidenceItem]) -> EvidencePack:
+    return EvidencePack(
+        query=_make_query(),
+        constraints_summary={},
+        evidence=tuple(items),
+        trace=PipelineTrace(
+            total_candidates=len(items),
+            group_count=0,
+            group_summaries=(),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — segment count & support type
+# ---------------------------------------------------------------------------
+
+
+def test_single_evidence_produces_primary_only():
+    primary = _make_item("c1", rank=1)
+    segments = compose_segments(_make_pack([primary]))
+    assert len(segments) == 1
+    assert segments[0].role == "primary"
+    assert segments[0].segment_id == "seg_1"
+
+
+def test_primary_with_exact_phrase_is_direct_support():
+    primary = _make_item("c1", rank=1, signals=_make_signals(exact=["foo"]))
+    segments = compose_segments(_make_pack([primary]))
+    assert segments[0].support_type == "direct_support"
+
+
+def test_primary_with_only_section_path_hit_is_supported_inference():
+    primary = _make_item("c1", rank=1, signals=_make_signals(section_path_hit=True))
+    segments = compose_segments(_make_pack([primary]))
+    assert segments[0].support_type == "supported_inference"
+
+
+def test_primary_with_two_siblings_yields_three_segments_same_group():
+    primary = _make_item("c1", rank=1)
+    sib1 = _make_item("c2", rank=2)
+    sib2 = _make_item("c3", rank=3)
+    segments = compose_segments(_make_pack([primary, sib1, sib2]))
+    assert len(segments) == 3
+    assert segments[1].role == "sibling"
+    assert segments[2].role == "sibling"
+    keys = {
+        (s.evidence_item.document_id, s.evidence_item.section_root) for s in segments
+    }
+    assert len(keys) == 1
+
+
+def test_sibling_plus_distinct_cross_section_fills_slot2():
+    primary = _make_item(
+        "c1", rank=1, signals=_make_signals(exact=["A"])
+    )
+    sib = _make_item("c2", rank=2)
+    cross = _make_item(
+        "c3",
+        rank=3,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["B"]),
+    )
+    segments = compose_segments(_make_pack([primary, sib, cross]))
+    assert len(segments) == 3
+    assert segments[2].role == "cross-section"
+    assert segments[2].evidence_item.section_root != primary.section_root
+
+
+def test_cross_section_subset_falls_back_to_second_sibling():
+    primary = _make_item(
+        "c1", rank=1, signals=_make_signals(exact=["A", "B"])
+    )
+    sib1 = _make_item("c2", rank=2)
+    cross = _make_item(
+        "c3",
+        rank=3,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["A"]),
+    )
+    sib2 = _make_item("c4", rank=4)
+    segments = compose_segments(_make_pack([primary, sib1, cross, sib2]))
+    assert len(segments) == 3
+    assert segments[1].evidence_item.chunk_id == "c2"
+    assert segments[2].role == "sibling"
+    assert segments[2].evidence_item.chunk_id == "c4"
+
+
+def test_cross_section_subset_no_second_sibling_leaves_slot2_empty():
+    primary = _make_item(
+        "c1", rank=1, signals=_make_signals(exact=["A", "B"])
+    )
+    sib = _make_item("c2", rank=2)
+    cross = _make_item(
+        "c3",
+        rank=3,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["A"]),
+    )
+    segments = compose_segments(_make_pack([primary, sib, cross]))
+    assert len(segments) == 2
+    assert segments[1].role == "sibling"
+
+
+def test_primary_plus_cross_section_without_siblings():
+    primary = _make_item("c1", rank=1, signals=_make_signals(exact=["A"]))
+    cross = _make_item(
+        "c2",
+        rank=2,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["B"]),
+    )
+    segments = compose_segments(_make_pack([primary, cross]))
+    assert len(segments) == 2
+    assert segments[1].role == "cross-section"
+    assert segments[1].evidence_item.chunk_id == "c2"
+
+
+def test_cross_section_lowest_rank_wins():
+    primary = _make_item("c1", rank=1, signals=_make_signals(exact=["A"]))
+    cross_far = _make_item(
+        "c2",
+        rank=5,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["B"]),
+    )
+    cross_near = _make_item(
+        "c3",
+        rank=3,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["C"]),
+    )
+    segments = compose_segments(_make_pack([primary, cross_near, cross_far]))
+    assert len(segments) == 2
+    assert segments[1].evidence_item.chunk_id == "c3"
+
+
+def test_empty_primary_hitset_accepts_any_cross_section_with_phrase_hits():
+    """Per §3.3 edge case — empty primary hit set trivially has no subset match."""
+    primary = _make_item(
+        "c1", rank=1, signals=_make_signals(section_path_hit=True)
+    )
+    cross = _make_item(
+        "c2",
+        rank=2,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["X"]),
+    )
+    segments = compose_segments(_make_pack([primary, cross]))
+    assert len(segments) == 2
+    assert segments[1].role == "cross-section"
+
+
+# ---------------------------------------------------------------------------
+# Tests — excerpt truncation
+# ---------------------------------------------------------------------------
+
+
+def test_content_501_chars_truncated():
+    content = "x" * 501
+    primary = _make_item("c1", rank=1, content=content)
+    segments = compose_segments(_make_pack([primary]))
+    text = segments[0].text
+    assert text.endswith("…")
+    # 500 chars + the ellipsis character
+    assert len(text) == 501
+
+
+def test_content_500_chars_not_truncated():
+    content = "x" * 500
+    primary = _make_item("c1", rank=1, content=content)
+    segments = compose_segments(_make_pack([primary]))
+    assert segments[0].text == content
+
+
+def test_content_100_chars_not_truncated():
+    content = "x" * 100
+    primary = _make_item("c1", rank=1, content=content)
+    segments = compose_segments(_make_pack([primary]))
+    assert segments[0].text == content

--- a/tests/test_answer_pipeline.py
+++ b/tests/test_answer_pipeline.py
@@ -1,0 +1,239 @@
+"""Tests for ``build_answer`` and the strict/debug JSON serializers."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT7
+
+from scripts.answer.composer import compose_segments
+from scripts.answer.contracts import Abstention, GroundedAnswer
+from scripts.answer.pipeline import build_answer, to_debug_json, to_strict_json
+from scripts.retrieval.contracts import MatchSignals, NormalizedQuery
+from scripts.retrieval.evidence_pack import (
+    EvidenceItem,
+    EvidencePack,
+    GroupSummary,
+    PipelineTrace,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCHEMAS_DIR = _REPO_ROOT / "schemas"
+
+_SOURCE_REF = {
+    "source_id": "srd_35",
+    "title": "System Reference Document",
+    "edition": "3.5e",
+    "source_type": "srd",
+    "authority_level": "official_reference",
+}
+
+
+def _make_query(raw: str = "attack of opportunity") -> NormalizedQuery:
+    return NormalizedQuery(
+        raw_query=raw,
+        normalized_text=raw,
+        tokens=raw.split(),
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+
+
+def _make_signals(
+    *,
+    exact: list[str] | None = None,
+    protected: list[str] | None = None,
+    section_path_hit: bool = False,
+    token_overlap_count: int = 0,
+) -> MatchSignals:
+    return {
+        "exact_phrase_hits": list(exact or []),
+        "protected_phrase_hits": list(protected or []),
+        "section_path_hit": section_path_hit,
+        "token_overlap_count": token_overlap_count,
+    }
+
+
+def _make_item(
+    chunk_id: str,
+    *,
+    rank: int,
+    document_id: str = "doc::main",
+    section_root: str = "Combat",
+    content: str = "Rule text.",
+    signals: MatchSignals | None = None,
+) -> EvidenceItem:
+    return EvidenceItem(
+        chunk_id=chunk_id,
+        document_id=document_id,
+        rank=rank,
+        content=content,
+        chunk_type="rule_section",
+        source_ref=_SOURCE_REF,
+        locator={"section_path": [section_root, "X"], "source_location": "t"},
+        match_signals=signals or _make_signals(exact=["q"]),
+        section_root=section_root,
+    )
+
+
+def _make_pack(
+    items: list[EvidenceItem],
+    *,
+    raw_query: str = "attack of opportunity",
+) -> EvidencePack:
+    group_summaries = tuple(
+        GroupSummary(
+            document_id=item.document_id,
+            section_root=item.section_root,
+            candidate_count=1,
+        )
+        for item in items
+    )
+    return EvidencePack(
+        query=_make_query(raw_query),
+        constraints_summary={},
+        evidence=tuple(items),
+        trace=PipelineTrace(
+            total_candidates=len(items),
+            group_count=len(group_summaries),
+            group_summaries=group_summaries,
+        ),
+    )
+
+
+def _make_validator() -> Draft7Validator:
+    main = json.loads(
+        (_SCHEMAS_DIR / "answer_with_citations.schema.json").read_text(encoding="utf-8")
+    )
+    common = json.loads(
+        (_SCHEMAS_DIR / "common.schema.json").read_text(encoding="utf-8")
+    )
+    common_resource = Resource.from_contents(common, default_specification=DRAFT7)
+    registry = Registry().with_resources(
+        [
+            ("./common.schema.json", common_resource),
+            ("common.schema.json", common_resource),
+        ]
+    )
+    return Draft7Validator(main, registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# build_answer — outcome dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_empty_pack_returns_abstention_with_canned_reason():
+    pack = _make_pack([])
+    result = build_answer(pack)
+    assert isinstance(result, Abstention)
+    assert result.trigger_code == "empty_evidence"
+    assert result.reason == "Insufficient evidence: no chunks retrieved for this query."
+
+
+def test_weak_signals_returns_abstention_with_canned_reason():
+    weak = _make_item("c1", rank=1, signals=_make_signals(token_overlap_count=5))
+    result = build_answer(_make_pack([weak]))
+    assert isinstance(result, Abstention)
+    assert result.trigger_code == "weak_signals"
+    assert (
+        result.reason
+        == "Insufficient evidence: retrieved chunks do not clearly match the query."
+    )
+
+
+def test_grounded_with_sibling_and_cross_section_produces_three_segments():
+    primary = _make_item("c1", rank=1, signals=_make_signals(exact=["A"]))
+    sibling = _make_item("c2", rank=2, signals=_make_signals(exact=["A"]))
+    cross = _make_item(
+        "c3",
+        rank=3,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["B"]),
+    )
+    pack = _make_pack([primary, sibling, cross])
+    result = build_answer(pack)
+    assert isinstance(result, GroundedAnswer)
+    assert len(result.segments) == 3
+    assert len(result.citations) == 3
+    assert result.query == pack.query.raw_query
+
+
+# ---------------------------------------------------------------------------
+# Strict JSON — schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_strict_json_grounded_validates_against_schema():
+    primary = _make_item("c1", rank=1, signals=_make_signals(exact=["A"]))
+    cross = _make_item(
+        "c2",
+        rank=2,
+        document_id="doc::other",
+        section_root="Spells",
+        signals=_make_signals(exact=["B"]),
+    )
+    pack = _make_pack([primary, cross])
+    result = build_answer(pack)
+
+    payload = to_strict_json(result, pack)
+    _make_validator().validate(payload)
+
+    assert payload["answer_type"] == "grounded"
+    assert payload["retrieval_metadata"]["candidate_chunks"] == 2
+    assert payload["retrieval_metadata"]["selected_chunks"] == 2
+
+
+def test_strict_json_abstain_validates_against_schema():
+    pack = _make_pack([])
+    result = build_answer(pack)
+    payload = to_strict_json(result, pack)
+    _make_validator().validate(payload)
+    assert payload["answer_type"] == "abstain"
+    assert (
+        payload["abstention_reason"]
+        == "Insufficient evidence: no chunks retrieved for this query."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Debug JSON — strict shape after popping `debug`
+# ---------------------------------------------------------------------------
+
+
+def test_debug_json_grounded_strict_shape_after_pop():
+    primary = _make_item("c1", rank=1, signals=_make_signals(exact=["A"]))
+    sibling = _make_item("c2", rank=2, signals=_make_signals(exact=["A"]))
+    pack = _make_pack([primary, sibling])
+    result = build_answer(pack)
+    composed = compose_segments(pack)
+
+    payload = to_debug_json(result, pack, composed)
+    debug = payload.pop("debug")
+    _make_validator().validate(payload)
+
+    assert set(debug.keys()) == {"abstention_code", "pipeline_trace", "selected_items"}
+    assert debug["abstention_code"] is None
+    assert len(debug["selected_items"]) == len(composed)
+    for entry in debug["selected_items"]:
+        assert set(entry.keys()) >= {"chunk_id", "rank", "match_signals", "role"}
+
+
+def test_debug_json_abstain_has_code_and_empty_selected_items():
+    pack = _make_pack([])
+    result = build_answer(pack)
+    payload = to_debug_json(result, pack, ())
+    debug = payload.pop("debug")
+    _make_validator().validate(payload)
+
+    assert debug["abstention_code"] == "empty_evidence"
+    assert debug["selected_items"] == []

--- a/tests/test_answer_support_assessor.py
+++ b/tests/test_answer_support_assessor.py
@@ -1,0 +1,120 @@
+"""Tests for the answer-stage support assessor (§3.2)."""
+from __future__ import annotations
+
+from scripts.answer.support_assessor import assess_support
+from scripts.retrieval.contracts import MatchSignals, NormalizedQuery
+from scripts.retrieval.evidence_pack import (
+    EvidenceItem,
+    EvidencePack,
+    PipelineTrace,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_query(raw: str = "attack of opportunity") -> NormalizedQuery:
+    return NormalizedQuery(
+        raw_query=raw,
+        normalized_text=raw,
+        tokens=raw.split(),
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+
+
+def _make_signals(
+    *,
+    exact: list[str] | None = None,
+    protected: list[str] | None = None,
+    section_path_hit: bool = False,
+    token_overlap_count: int = 0,
+) -> MatchSignals:
+    return {
+        "exact_phrase_hits": list(exact or []),
+        "protected_phrase_hits": list(protected or []),
+        "section_path_hit": section_path_hit,
+        "token_overlap_count": token_overlap_count,
+    }
+
+
+def _make_item(signals: MatchSignals, *, chunk_id: str = "chunk::001") -> EvidenceItem:
+    return EvidenceItem(
+        chunk_id=chunk_id,
+        document_id="doc::test",
+        rank=1,
+        content="Top item content.",
+        chunk_type="rule_section",
+        source_ref={
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        locator={"section_path": ["Combat"], "source_location": "test"},
+        match_signals=signals,
+        section_root="Combat",
+    )
+
+
+def _make_pack(items: list[EvidenceItem]) -> EvidencePack:
+    return EvidencePack(
+        query=_make_query(),
+        constraints_summary={},
+        evidence=tuple(items),
+        trace=PipelineTrace(
+            total_candidates=len(items),
+            group_count=0,
+            group_summaries=(),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_empty_evidence_abstains():
+    pack = _make_pack([])
+    result = assess_support(pack)
+    assert result.outcome == "abstain"
+    assert result.trigger_code == "empty_evidence"
+
+
+def test_exact_phrase_hit_grounded():
+    item = _make_item(_make_signals(exact=["foo"]))
+    result = assess_support(_make_pack([item]))
+    assert result.outcome == "grounded"
+    assert result.trigger_code is None
+
+
+def test_protected_phrase_hit_grounded():
+    item = _make_item(_make_signals(protected=["bar"]))
+    result = assess_support(_make_pack([item]))
+    assert result.outcome == "grounded"
+    assert result.trigger_code is None
+
+
+def test_section_path_hit_alone_grounded():
+    item = _make_item(_make_signals(section_path_hit=True))
+    result = assess_support(_make_pack([item]))
+    assert result.outcome == "grounded"
+    assert result.trigger_code is None
+
+
+def test_token_overlap_alone_abstains():
+    item = _make_item(_make_signals(token_overlap_count=5))
+    result = assess_support(_make_pack([item]))
+    assert result.outcome == "abstain"
+    assert result.trigger_code == "weak_signals"
+
+
+def test_zero_signals_abstains():
+    item = _make_item(_make_signals())
+    result = assess_support(_make_pack([item]))
+    assert result.outcome == "abstain"
+    assert result.trigger_code == "weak_signals"


### PR DESCRIPTION
## Summary

Implements the minimal rule-based answer path designed in #70 (merged in b69a90a). Every decision in the pipeline is a function of existing `match_signals` and `candidate_shaping` output — no LLM involved. This is the **excerpt-based validation scaffold** declared in the spec; a prose-synthesizing composer is the planned v2 successor over the same \`EvidencePack\` interface.

Unblocks #24 (gold-set evaluation run) and advances rollup #5.

## Pipeline

\`\`\`
EvidencePack → assess_support → {grounded | abstain}
                     │
                     ├─ grounded → compose_segments → bind_citations → GroundedAnswer
                     └─ abstain  →                                     Abstention
\`\`\`

- **assess_support** (§3.2): strict-signal gate. Abstain unless the top evidence item has at least one of \`exact_phrase_hit\`, \`protected_phrase_hit\`, or \`section_path_hit\`. Trigger codes: \`empty_evidence\`, \`weak_signals\`.
- **compose_segments** (§3.3): primary segment from \`pack.evidence[0]\`, truncated to 500 chars, plus up to 2 supporting slots. Slot 1 is the next-ranked sibling in the primary's \`(document_id, section_root)\` group. Slot 2 picks a distinct-signal cross-section item (exact/protected hit set not a subset of primary's, lowest-rank wins) or falls back to a second sibling.
- **bind_citations** (§3.4): assigns \`cit_1\`, \`cit_2\`, … in segment order; dedupes when \`(chunk_id, excerpt)\` tuple repeats.
- **build_answer** (§3.1): single entry point orchestrating the three above.

## CLI

\`scripts/answer_question.py\`:
- Text mode (default), \`--json\` (strict schema), \`--json-debug\` (extended with top-level \`debug\` key, non-schema-valid by design).
- \`--json\` and \`--json-debug\` mutually exclusive.
- Missing-index guard: clear stderr message + exit 1.

## Evidence (§6 of PR evidence standard)

Ran the CLI against the regenerated fixture index:

**\`--json\` output** (first 10 lines):
\`\`\`
{
  \"query\": \"attack of opportunity\",
  \"answer_type\": \"grounded\",
  \"answer_segments\": [
    {
      \"segment_id\": \"seg_1\",
      \"text\": \"You threaten all squares into which you can make a melee attack, ...\",
      \"support_type\": \"direct_support\",
      \"citation_ids\": [
        \"cit_1\"
\`\`\`

**Missing-db guard** (text mode, real db path doesn't exist in CI):
\`\`\`
Error: chunk index not found at .../data/index/srd_35/lexical.db
Build the lexical index first:
  python scripts/chunk_srd_35.py
\`\`\`

Two example artifacts regenerated via \`scripts/regen_examples.py\`:
- \`examples/evidence_pack.example.json\` (new, closes the small gap flagged on #22)
- \`examples/answer_with_citations.example.json\` (overwritten)

## Tests

31 new tests, all passing:

| File | Tests | Coverage |
|---|---|---|
| \`test_answer_support_assessor.py\` | 6 | every abstain trigger + every strong-signal grounded path |
| \`test_answer_composer.py\` | 13 | single-item, sibling filling, cross-section distinctness + tie-break, subset-rejection with/without fallback sibling, empty-primary-hitset edge case, 500/501/100-char truncation boundaries |
| \`test_answer_citation_binder.py\` | 5 | id assignment, dedupe by \`(chunk_id, excerpt)\`, excerpt=segment text, source_ref/locator pass-through |
| \`test_answer_pipeline.py\` | 7 | assessor-to-build_answer orchestration, canned abstain reasons, strict JSON + debug JSON schema validation (debug variant validated after popping the debug key) |

Full suite: **245 passed, 1 xfailed, 1 failed** — the one failure (\`test_ingest_srd_35::test_ingest_source_can_require_schema_validation\`, \`FileNotFoundError\` on a temp schema file) is pre-existing and unrelated to this change.

## Design decisions — quick reference

All decisions are locked in by the merged spec in \`docs/plans/2026-04-23-issue-23-minimal-answer-path.md\`. Quick recap:

1. **Strict-signal abstain gate.** Token overlap alone never licenses a grounded answer. #24 will surface \"unnecessary abstain\" as tagged failure data.
2. **Length-cap truncation** (500 chars + \"…\"). Hit-anchored windowing deferred.
3. **Two CLI JSON contracts**, not one hybrid — schema's \`additionalProperties: false\` at top level forbids mixed output.
4. **No LLM in v1, scaffold only.** LLM composer is the planned v2 over the same interface; don't start before #24 records the rule-based baseline's failure profile.

## Test plan

- [x] Unit tests for every module (31 tests, all passing)
- [x] Strict \`--json\` output validates against \`schemas/answer_with_citations.schema.json\`
- [x] \`--json-debug\` output validates against the same schema after popping the \`debug\` key
- [x] CLI smoke: text / \`--json\` / \`--json-debug\` modes all produce expected output
- [x] Missing-db guard: clear stderr message + exit 1
- [x] No regressions: full test suite (excluding one pre-existing failure)
- [ ] Follow-up: open issue for the v2 LLM composer after #24 lands, per spec §8.8

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)