### PR TITLE
feat(ingestion): formatting-driven entry annotator (#60 part 2/4)

### DIFF
--- a/configs/content_types.yaml
+++ b/configs/content_types.yaml
@@ -1,0 +1,43 @@
+# configs/content_types.yaml
+# Declarative content-type registry for entry detection.
+# Each entry binds a semantic identity to a shape family + parameters.
+# Adding a new content type or source: add an entry here, no code change.
+
+content_types:
+  - name: spell
+    category: Spells
+    chunk_type: spell_entry
+    shape: entry_with_statblock
+    shape_params:
+      max_title_len: 80
+      max_subtitle_len: 80
+      min_fields: 2
+      field_pattern: "^[A-Z][\\w '/-]+:"
+    file_match:
+      - "Spells*.rtf"
+      - "EpicSpells.rtf"
+      - "DivineDomainsandSpells.rtf"
+
+  - name: feat
+    category: Feats
+    chunk_type: feat_entry
+    shape: entry_with_statblock
+    shape_params:
+      max_title_len: 80
+      max_subtitle_len: 40
+      min_fields: 1
+      field_pattern: "^[A-Z][\\w '/-]+:"
+    file_match:
+      - "Feats.rtf"
+      - "EpicFeats.rtf"
+      - "DivineAbilitiesandFeats.rtf"
+
+  - name: condition
+    category: Conditions
+    chunk_type: condition_entry
+    shape: definition_list
+    shape_params:
+      min_blocks: 3
+      term_pattern: "^[A-Z][\\w '/-]*:\\s+\\S"
+    file_match:
+      - "AbilitiesandConditions.rtf"

--- a/schemas/content_types.schema.json
+++ b/schemas/content_types.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ContentTypesConfig",
+  "type": "object",
+  "required": ["content_types"],
+  "additionalProperties": false,
+  "properties": {
+    "content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "category", "chunk_type", "shape"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {"type": "string", "minLength": 1},
+          "category": {"type": "string", "minLength": 1},
+          "chunk_type": {
+            "type": "string",
+            "enum": ["spell_entry", "feat_entry", "skill_entry", "condition_entry", "class_feature", "glossary_entry"]
+          },
+          "shape": {
+            "type": "string",
+            "enum": ["entry_with_statblock", "definition_list"]
+          },
+          "shape_params": {
+            "type": "object"
+          },
+          "file_match": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/ingest_srd35/content_types.py
+++ b/scripts/ingest_srd35/content_types.py
@@ -1,0 +1,67 @@
+"""Declarative content-type registry for entry detection.
+
+A ContentTypeConfig binds:
+  - a semantic identity (name, category, chunk_type)
+  - a shape family (e.g., entry_with_statblock)
+  - shape parameters (per-shape configuration)
+  - an optional file_match allowlist (glob patterns)
+
+The registry is loaded from a YAML config file and consumed by the
+entry annotator. Downstream code never imports this module — annotations
+on blocks carry the semantic payload forward.
+"""
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True)
+class ContentTypeConfig:
+    name: str
+    category: str
+    chunk_type: str
+    shape: str
+    shape_params: dict[str, Any]
+    file_match: list[str] | None = None
+
+
+def load_content_types(yaml_text: str) -> list[ContentTypeConfig]:
+    """Parse YAML content_types declarations into config objects."""
+    data = yaml.safe_load(yaml_text)
+    if not isinstance(data, dict) or "content_types" not in data:
+        raise ValueError("content_types YAML must have top-level 'content_types' list")
+    types: list[ContentTypeConfig] = []
+    for entry in data["content_types"]:
+        types.append(ContentTypeConfig(
+            name=entry["name"],
+            category=entry["category"],
+            chunk_type=entry["chunk_type"],
+            shape=entry["shape"],
+            shape_params=entry.get("shape_params", {}),
+            file_match=entry.get("file_match"),
+        ))
+    return types
+
+
+def eligible_types_for_file(
+    file_name: str,
+    types: list[ContentTypeConfig],
+) -> list[ContentTypeConfig]:
+    """Return the subset of types eligible for a file.
+
+    A type is eligible when:
+      - file_match is None (always eligible), OR
+      - file_name matches at least one glob in file_match.
+    """
+    eligible: list[ContentTypeConfig] = []
+    for t in types:
+        if t.file_match is None:
+            eligible.append(t)
+            continue
+        if any(fnmatch.fnmatch(file_name, pattern) for pattern in t.file_match):
+            eligible.append(t)
+    return eligible

--- a/scripts/ingest_srd35/entry_annotator.py
+++ b/scripts/ingest_srd35/entry_annotator.py
@@ -1,0 +1,285 @@
+"""Formatting-driven entry detection that runs on raw IR blocks.
+
+Annotates blocks in place with entry roles. Downstream consumers
+(sectioning, boundary filter, canonical emission) read annotations
+only; they never import ContentTypeConfig.
+
+Detection is shape-driven within a typed config layer:
+  - Shape rules are vocabulary-free pattern matchers over font_size
+    and starts_with_bold.
+  - Type config (content_types.yaml) binds semantic identity to a
+    shape and provides per-type shape parameters.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+from .content_types import ContentTypeConfig, eligible_types_for_file
+
+
+class EntryAnnotationConflict(Exception):
+    """Raised when shapes claim overlapping blocks or re-annotation is attempted."""
+
+
+@dataclass(frozen=True)
+class _Match:
+    """A successful shape match over a contiguous block range."""
+    start_index: int   # inclusive
+    end_index: int     # exclusive
+    title_index: int
+    subtitle_index: int | None  # None for definition_list (each block is its own entry)
+    field_indices: tuple[int, ...]
+    description_indices: tuple[int, ...]
+    title_text: str
+    type_config: ContentTypeConfig
+
+
+def annotate_entries(
+    blocks: list[dict],
+    *,
+    file_name: str,
+    content_types: list[ContentTypeConfig],
+) -> list[dict]:
+    """Annotate blocks with entry roles. Mutates and returns blocks.
+
+    Owns eligibility filtering and shape execution. Raises
+    EntryAnnotationConflict if shapes claim overlapping blocks or
+    if any block already carries entry annotations.
+    """
+    if any("entry_index" in b for b in blocks):
+        raise EntryAnnotationConflict(
+            f"annotate_entries called on already-annotated blocks (file={file_name})"
+        )
+
+    eligible = eligible_types_for_file(file_name, content_types)
+    if not eligible:
+        return blocks
+
+    all_matches: list[tuple[_Match, str]] = []  # (match, shape_family)
+    for cfg in eligible:
+        if cfg.shape == "entry_with_statblock":
+            for m in _find_entry_with_statblock_matches(blocks, cfg):
+                all_matches.append((m, "entry_with_statblock"))
+        elif cfg.shape == "definition_list":
+            for m in _find_definition_list_matches(blocks, cfg):
+                all_matches.append((m, "definition_list"))
+        else:
+            raise ValueError(f"Unknown shape: {cfg.shape}")
+
+    # Conflict detection: any two matches' [start, end) overlap.
+    sorted_matches = sorted(all_matches, key=lambda mm: mm[0].start_index)
+    for i in range(len(sorted_matches) - 1):
+        m_a, _ = sorted_matches[i]
+        m_b, _ = sorted_matches[i + 1]
+        if m_b.start_index < m_a.end_index:
+            raise EntryAnnotationConflict(
+                f"Overlapping shape matches in {file_name}: "
+                f"{m_a.type_config.name} blocks [{m_a.start_index},{m_a.end_index}) "
+                f"vs {m_b.type_config.name} blocks [{m_b.start_index},{m_b.end_index}). "
+                f"Hint: narrow file_match in content_types.yaml."
+            )
+
+    # Apply annotations.
+    next_index_by_type: dict[str, int] = {}
+    for match, shape_family in sorted_matches:
+        type_name = match.type_config.name
+        entry_index = next_index_by_type.get(type_name, 0)
+        next_index_by_type[type_name] = entry_index + 1
+        _apply_match(blocks, match, shape_family, entry_index)
+
+    return blocks
+
+
+# ----------------------------------------------------------------------
+# entry_with_statblock shape
+# ----------------------------------------------------------------------
+
+def _find_entry_with_statblock_matches(
+    blocks: list[dict], cfg: ContentTypeConfig,
+) -> Iterable[_Match]:
+    params = cfg.shape_params
+    max_title_len: int = params.get("max_title_len", 80)
+    max_subtitle_len: int = params.get("max_subtitle_len", 80)
+    min_fields: int = params.get("min_fields", 2)
+    field_pattern = re.compile(params.get("field_pattern", r"^[A-Z][\w '/-]+:"))
+
+    candidates: list[_Match] = []
+    n = len(blocks)
+    i = 0
+    while i < n - 2:
+        title = blocks[i]
+        subtitle = blocks[i + 1]
+        if not _is_valid_title(title, max_title_len, field_pattern):
+            i += 1
+            continue
+        if not _is_valid_subtitle(subtitle, title, max_subtitle_len):
+            i += 1
+            continue
+
+        # Count consecutive field blocks.
+        field_indices: list[int] = []
+        j = i + 2
+        while j < n and _is_field_block(blocks[j], subtitle, field_pattern):
+            field_indices.append(j)
+            j += 1
+        if len(field_indices) < min_fields:
+            i += 1
+            continue
+
+        # We have a candidate match starting at i. Provisional end_index
+        # is end-of-fields; description blocks (the prose between this
+        # entry and the next title) get attached after we know the next
+        # match position.
+        candidates.append(_Match(
+            start_index=i,
+            end_index=j,  # exclusive — provisional, extended below
+            title_index=i,
+            subtitle_index=i + 1,
+            field_indices=tuple(field_indices),
+            description_indices=(),  # filled in below
+            title_text=title["text"].strip(),
+            type_config=cfg,
+        ))
+        i = j  # skip past consumed blocks
+    # Extend each match's end_index to include description blocks up to the next match (or EOF).
+    extended: list[_Match] = []
+    for idx, m in enumerate(candidates):
+        next_start = candidates[idx + 1].start_index if idx + 1 < len(candidates) else n
+        desc_indices = tuple(range(m.end_index, next_start))
+        extended.append(_Match(
+            start_index=m.start_index,
+            end_index=next_start,
+            title_index=m.title_index,
+            subtitle_index=m.subtitle_index,
+            field_indices=m.field_indices,
+            description_indices=desc_indices,
+            title_text=m.title_text,
+            type_config=m.type_config,
+        ))
+    return extended
+
+
+def _is_valid_title(block: dict, max_len: int, field_pattern: re.Pattern) -> bool:
+    text = block.get("text", "").strip()
+    if not text:
+        return False
+    if len(text) > max_len:
+        return False
+    if block.get("starts_with_bold", False):
+        return False
+    if field_pattern.match(text):
+        return False  # title-as-field guard
+    return True
+
+
+def _is_valid_subtitle(block: dict, title: dict, max_len: int) -> bool:
+    text = block.get("text", "").strip()
+    if not text:
+        return False
+    if len(text) > max_len:
+        return False
+    if block.get("starts_with_bold", False):
+        return False
+    if block.get("font_size", 0) >= title.get("font_size", 0):
+        return False  # strict step-down
+    return True
+
+
+def _is_field_block(block: dict, subtitle: dict, field_pattern: re.Pattern) -> bool:
+    if not block.get("starts_with_bold", False):
+        return False
+    if block.get("font_size", 0) != subtitle.get("font_size", 0):
+        return False
+    text = block.get("text", "").strip()
+    return bool(field_pattern.match(text))
+
+
+# ----------------------------------------------------------------------
+# definition_list shape
+# ----------------------------------------------------------------------
+
+def _find_definition_list_matches(
+    blocks: list[dict], cfg: ContentTypeConfig,
+) -> Iterable[_Match]:
+    params = cfg.shape_params
+    min_blocks: int = params.get("min_blocks", 3)
+    term_pattern = re.compile(params.get("term_pattern", r"^[A-Z][\w '/-]*:\s+\S"))
+
+    n = len(blocks)
+    matches: list[_Match] = []
+    i = 0
+    while i < n:
+        if not _is_def_block(blocks[i], term_pattern):
+            i += 1
+            continue
+        # Scan forward while same font_size + matches term_pattern.
+        run_size = blocks[i]["font_size"]
+        j = i
+        run_indices: list[int] = []
+        while j < n and _is_def_block(blocks[j], term_pattern) and blocks[j]["font_size"] == run_size:
+            run_indices.append(j)
+            j += 1
+        if len(run_indices) >= min_blocks:
+            # Each block in the run is its own entry (single-block).
+            for block_idx in run_indices:
+                title_text = _definition_term(blocks[block_idx]["text"])
+                matches.append(_Match(
+                    start_index=block_idx,
+                    end_index=block_idx + 1,
+                    title_index=block_idx,
+                    subtitle_index=None,
+                    field_indices=(),
+                    description_indices=(),
+                    title_text=title_text,
+                    type_config=cfg,
+                ))
+        i = j
+    return matches
+
+
+def _is_def_block(block: dict, term_pattern: re.Pattern) -> bool:
+    if not block.get("starts_with_bold", False):
+        return False
+    text = block.get("text", "").strip()
+    return bool(term_pattern.match(text))
+
+
+def _definition_term(text: str) -> str:
+    return text.split(":", 1)[0].strip()
+
+
+# ----------------------------------------------------------------------
+# Annotation application
+# ----------------------------------------------------------------------
+
+def _apply_match(
+    blocks: list[dict],
+    match: _Match,
+    shape_family: str,
+    entry_index: int,
+) -> None:
+    cfg = match.type_config
+    base = {
+        "entry_index": entry_index,
+        "entry_type": cfg.name,
+        "entry_category": cfg.category,
+        "entry_chunk_type": cfg.chunk_type,
+        "entry_title": match.title_text,
+        "shape_family": shape_family,
+    }
+
+    if shape_family == "definition_list":
+        # Single-block entry: one block is title + definition combined.
+        blocks[match.title_index].update({**base, "entry_role": "definition"})
+        return
+
+    # entry_with_statblock
+    blocks[match.title_index].update({**base, "entry_role": "title"})
+    if match.subtitle_index is not None:
+        blocks[match.subtitle_index].update({**base, "entry_role": "subtitle"})
+    for fi in match.field_indices:
+        blocks[fi].update({**base, "entry_role": "stat_field"})
+    for di in match.description_indices:
+        blocks[di].update({**base, "entry_role": "description"})

--- a/scripts/ingest_srd35/entry_annotator.py
+++ b/scripts/ingest_srd35/entry_annotator.py
@@ -142,14 +142,18 @@ def _find_entry_with_statblock_matches(
             type_config=cfg,
         ))
         i = j  # skip past consumed blocks
-    # Extend each match's end_index to include description blocks up to the next match (or EOF).
+    # Extend each match's end_index to include description blocks up to the
+    # next match (or EOF — but stop at the first heading_candidate so trailing
+    # section headings, footers preceded by a heading, etc. are not absorbed
+    # as the last entry's description).
     extended: list[_Match] = []
     for idx, m in enumerate(candidates):
-        next_start = candidates[idx + 1].start_index if idx + 1 < len(candidates) else n
-        desc_indices = tuple(range(m.end_index, next_start))
+        hard_stop = candidates[idx + 1].start_index if idx + 1 < len(candidates) else n
+        desc_end = _description_end(blocks, m.end_index, hard_stop)
+        desc_indices = tuple(range(m.end_index, desc_end))
         extended.append(_Match(
             start_index=m.start_index,
-            end_index=next_start,
+            end_index=desc_end,
             title_index=m.title_index,
             subtitle_index=m.subtitle_index,
             field_indices=m.field_indices,
@@ -158,6 +162,23 @@ def _find_entry_with_statblock_matches(
             type_config=m.type_config,
         ))
     return extended
+
+
+def _description_end(blocks: list[dict], start: int, hard_stop: int) -> int:
+    """Return the exclusive end index for an entry's description range.
+
+    Walks blocks[start:hard_stop] and stops at the first block whose
+    block_type is heading_candidate — the IR's heading detector has
+    already flagged it as a section boundary. This prevents the final
+    entry in a file from absorbing trailing section headings (and any
+    blocks beyond them) as its own description. Pure-prose footers
+    without a heading marker will still be absorbed; that's a known
+    limit, not a bug.
+    """
+    for k in range(start, hard_stop):
+        if blocks[k].get("block_type") == "heading_candidate":
+            return k
+    return hard_stop
 
 
 def _is_valid_title(block: dict, max_len: int, field_pattern: re.Pattern) -> bool:
@@ -214,10 +235,17 @@ def _find_definition_list_matches(
             i += 1
             continue
         # Scan forward while same font_size + matches term_pattern.
-        run_size = blocks[i]["font_size"]
+        # Use .get() consistently with entry_with_statblock predicates so a
+        # raw IR block missing font_size simply doesn't match (rather than
+        # raising KeyError mid-scan).
+        run_size = blocks[i].get("font_size", 0)
         j = i
         run_indices: list[int] = []
-        while j < n and _is_def_block(blocks[j], term_pattern) and blocks[j]["font_size"] == run_size:
+        while (
+            j < n
+            and _is_def_block(blocks[j], term_pattern)
+            and blocks[j].get("font_size", 0) == run_size
+        ):
             run_indices.append(j)
             j += 1
         if len(run_indices) >= min_blocks:

--- a/scripts/ingest_srd35/entry_annotator.py
+++ b/scripts/ingest_srd35/entry_annotator.py
@@ -81,12 +81,11 @@ def annotate_entries(
                 f"Hint: narrow file_match in content_types.yaml."
             )
 
-    # Apply annotations.
-    next_index_by_type: dict[str, int] = {}
-    for match, shape_family in sorted_matches:
-        type_name = match.type_config.name
-        entry_index = next_index_by_type.get(type_name, 0)
-        next_index_by_type[type_name] = entry_index + 1
+    # Apply annotations. entry_index is a single monotonic counter over the
+    # file (NOT per-type), so disjoint matches from different types still get
+    # globally-unique indices — required for downstream grouping by entry_index
+    # to be unambiguous.
+    for entry_index, (match, shape_family) in enumerate(sorted_matches):
         _apply_match(blocks, match, shape_family, entry_index)
 
     return blocks

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
 import unittest
 from pathlib import Path
+
+import jsonschema
+import yaml
 
 from scripts.ingest_srd35.content_types import (
     ContentTypeConfig,
@@ -91,6 +95,16 @@ class EligibleTypesForFileTests(unittest.TestCase):
             "Anything.rtf", [self.spell, self.always],
         )
         self.assertEqual([t.name for t in eligible], ["any"])
+
+
+class ContentTypesConfigValidatesAgainstSchemaTests(unittest.TestCase):
+    def test_shipped_config_validates(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        with (repo_root / "configs" / "content_types.yaml").open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        with (repo_root / "schemas" / "content_types.schema.json").open("r", encoding="utf-8") as fh:
+            schema = json.load(fh)
+        jsonschema.validate(data, schema)
 
 
 if __name__ == "__main__":

--- a/tests/test_content_types.py
+++ b/tests/test_content_types.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.ingest_srd35.content_types import (
+    ContentTypeConfig,
+    load_content_types,
+    eligible_types_for_file,
+)
+
+
+class LoadContentTypesTests(unittest.TestCase):
+    def test_load_yaml(self) -> None:
+        yaml_text = """\
+content_types:
+  - name: spell
+    category: Spells
+    chunk_type: spell_entry
+    shape: entry_with_statblock
+    shape_params:
+      max_title_len: 80
+      max_subtitle_len: 80
+      min_fields: 2
+      field_pattern: '^[A-Z][\\w]+:'
+    file_match: ["Spells*.rtf"]
+"""
+        types = load_content_types(yaml_text)
+        self.assertEqual(len(types), 1)
+        spell = types[0]
+        self.assertEqual(spell.name, "spell")
+        self.assertEqual(spell.category, "Spells")
+        self.assertEqual(spell.chunk_type, "spell_entry")
+        self.assertEqual(spell.shape, "entry_with_statblock")
+        self.assertEqual(spell.shape_params["min_fields"], 2)
+        self.assertEqual(spell.file_match, ["Spells*.rtf"])
+
+    def test_no_file_match_means_always_eligible(self) -> None:
+        yaml_text = """\
+content_types:
+  - name: any_entry
+    category: Misc
+    chunk_type: spell_entry
+    shape: definition_list
+    shape_params:
+      min_blocks: 3
+      term_pattern: '^[A-Z]+:'
+"""
+        types = load_content_types(yaml_text)
+        self.assertEqual(types[0].file_match, None)
+
+
+class EligibleTypesForFileTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.spell = ContentTypeConfig(
+            name="spell", category="Spells", chunk_type="spell_entry",
+            shape="entry_with_statblock", shape_params={},
+            file_match=["Spells*.rtf", "EpicSpells.rtf"],
+        )
+        self.condition = ContentTypeConfig(
+            name="condition", category="Conditions", chunk_type="condition_entry",
+            shape="definition_list", shape_params={},
+            file_match=["AbilitiesandConditions.rtf"],
+        )
+        self.always = ContentTypeConfig(
+            name="any", category="Misc", chunk_type="spell_entry",
+            shape="entry_with_statblock", shape_params={},
+            file_match=None,
+        )
+
+    def test_glob_match(self) -> None:
+        types = [self.spell, self.condition]
+        eligible = eligible_types_for_file("SpellsS.rtf", types)
+        self.assertEqual([t.name for t in eligible], ["spell"])
+
+    def test_exact_match(self) -> None:
+        eligible = eligible_types_for_file(
+            "AbilitiesandConditions.rtf",
+            [self.spell, self.condition],
+        )
+        self.assertEqual([t.name for t in eligible], ["condition"])
+
+    def test_no_match(self) -> None:
+        eligible = eligible_types_for_file(
+            "Description.rtf", [self.spell, self.condition],
+        )
+        self.assertEqual(eligible, [])
+
+    def test_no_file_match_always_eligible(self) -> None:
+        eligible = eligible_types_for_file(
+            "Anything.rtf", [self.spell, self.always],
+        )
+        self.assertEqual([t.name for t in eligible], ["any"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_entry_annotator.py
+++ b/tests/test_entry_annotator.py
@@ -252,5 +252,56 @@ class MultiTypeOverlapTests(unittest.TestCase):
             annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[spell, cond])
 
 
+class FileWideMonotonicEntryIndexTests(unittest.TestCase):
+    def test_disjoint_multi_type_indices_are_globally_unique(self) -> None:
+        # Codex P1: with disjoint matches from two types, entry_index must
+        # be a single monotonic counter over the file, NOT per-type. Otherwise
+        # downstream grouping by entry_index would see ambiguous duplicates.
+        spell = ContentTypeConfig(
+            name="spell", category="Spells", chunk_type="spell_entry",
+            shape="entry_with_statblock",
+            shape_params={
+                "max_title_len": 80, "max_subtitle_len": 80,
+                "min_fields": 2, "field_pattern": r"^[A-Z][\w '/-]+:",
+            },
+            file_match=None,
+        )
+        cond = ContentTypeConfig(
+            name="condition", category="Conditions", chunk_type="condition_entry",
+            shape="definition_list",
+            shape_params={"min_blocks": 3, "term_pattern": r"^[A-Z][\w '/-]*:\s+\S"},
+            file_match=None,
+        )
+        blocks = [
+            # Conditions block first (single-block entries, indices 0..2 expected).
+            _block("Blinded: cannot see", font_size=18, starts_with_bold=True),
+            _block("Confused: rolls d%", font_size=18, starts_with_bold=True),
+            _block("Dazed: unable to act", font_size=18, starts_with_bold=True),
+            # Then a spell with sufficient gap (different fs, no bold-prefix
+            # term_pattern match) so detectors don't overlap.
+            _block("Sanctuary", font_size=24),
+            _block("Abjuration", font_size=20),
+            _block("Level: Clr 1", font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+        ]
+        annotate_entries(blocks, file_name="any.rtf", content_types=[spell, cond])
+        # Per-block sequence: 3 conditions (single-block entries 0,1,2) +
+        # 1 spell with 4 blocks all sharing entry_index 3.
+        annotated_indices = [b["entry_index"] for b in blocks if "entry_index" in b]
+        self.assertEqual(annotated_indices, [0, 1, 2, 3, 3, 3, 3])
+        # Distinct entries must have distinct globally-monotonic indices —
+        # NOT per-type (which would have given conditions [0,1,2] and
+        # spell [0]).
+        per_entry_index_per_type = {}
+        for b in blocks:
+            if "entry_index" not in b:
+                continue
+            per_entry_index_per_type.setdefault(b["entry_type"], set()).add(b["entry_index"])
+        # spell entry_index ∈ {3}; condition entry_indices ∈ {0,1,2}; intersection empty.
+        spell_indices = per_entry_index_per_type["spell"]
+        cond_indices = per_entry_index_per_type["condition"]
+        self.assertEqual(spell_indices & cond_indices, set())
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_entry_annotator.py
+++ b/tests/test_entry_annotator.py
@@ -20,10 +20,17 @@ SPELL_CFG = ContentTypeConfig(
 )
 
 
-def _block(text: str, *, font_size: int, starts_with_bold: bool = False, all_bold: bool = False) -> dict:
+def _block(
+    text: str,
+    *,
+    font_size: int,
+    starts_with_bold: bool = False,
+    all_bold: bool = False,
+    block_type: str = "paragraph",
+) -> dict:
     return {
         "block_id": f"b{abs(hash(text)) % 10000:04d}",
-        "block_type": "paragraph",
+        "block_type": block_type,
         "text": text,
         "font_size": font_size,
         "starts_with_bold": starts_with_bold,
@@ -301,6 +308,93 @@ class FileWideMonotonicEntryIndexTests(unittest.TestCase):
         spell_indices = per_entry_index_per_type["spell"]
         cond_indices = per_entry_index_per_type["condition"]
         self.assertEqual(spell_indices & cond_indices, set())
+
+
+class LastEntryDescriptionStopsAtHeadingTests(unittest.TestCase):
+    """Codex review: previously the last detected entry's description range
+    extended to EOF, absorbing trailing section headings, footers, license
+    text, etc. Now it stops at the first heading_candidate block."""
+
+    def test_last_entry_does_not_absorb_trailing_heading(self) -> None:
+        blocks = [
+            _block("Sanctuary", font_size=24),
+            _block("Abjuration", font_size=20),
+            _block("Level: Clr 1", font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+            _block("First sentence of description.", font_size=24),
+            _block("Second sentence of description.", font_size=24),
+            # Trailing section heading — must stop description here.
+            _block("LEGAL NOTICES", font_size=24, block_type="heading_candidate"),
+            _block("All content is OGL-licensed text...", font_size=24),
+        ]
+        annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        # Only the 4 entry blocks + 2 description sentences are annotated.
+        annotated = [b for b in blocks if "entry_index" in b]
+        self.assertEqual(len(annotated), 6)
+        # Trailing heading + footer prose remain unannotated.
+        self.assertNotIn("entry_index", blocks[6])
+        self.assertNotIn("entry_index", blocks[7])
+
+    def test_intermediate_entries_unaffected_by_heading_stop(self) -> None:
+        # Two consecutive spells: the first's description bound is the
+        # next match, not a heading. Heading stop only kicks in when
+        # there's no next match (i.e., the last entry).
+        blocks = [
+            _block("Sanctuary", font_size=24),
+            _block("Abjuration", font_size=20),
+            _block("Level: Clr 1", font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+            _block("Sanctuary description text.", font_size=24),
+            _block("Scare", font_size=24),
+            _block("Necromancy", font_size=20),
+            _block("Level: Brd 2", font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+        ]
+        annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        # All 9 blocks belong to one entry or the other.
+        annotated = [b for b in blocks if "entry_index" in b]
+        self.assertEqual(len(annotated), 9)
+
+
+class DefinitionListBlockShapeRobustnessTests(unittest.TestCase):
+    """Codex review: definition_list used direct dict indexing for
+    font_size and would KeyError on blocks lacking the field. .get()
+    now keeps it consistent with entry_with_statblock predicates so a
+    missing field simply means 'no match', not a crash."""
+
+    def test_block_missing_font_size_does_not_crash(self) -> None:
+        # Construct blocks WITHOUT the font_size key (simulates a raw IR
+        # block from a pipeline stage that didn't fill it in).
+        blocks = [
+            {
+                "block_id": "b0001",
+                "block_type": "paragraph",
+                "text": "Blinded: cannot see",
+                "starts_with_bold": True,
+                "all_bold": False,
+            },
+            {
+                "block_id": "b0002",
+                "block_type": "paragraph",
+                "text": "Confused: rolls d%",
+                "starts_with_bold": True,
+                "all_bold": False,
+            },
+            {
+                "block_id": "b0003",
+                "block_type": "paragraph",
+                "text": "Dazed: unable to act",
+                "starts_with_bold": True,
+                "all_bold": False,
+            },
+        ]
+        # Should not raise. Default font_size 0 is uniform → run matches.
+        annotate_entries(
+            blocks, file_name="AbilitiesandConditions.rtf",
+            content_types=[CONDITION_CFG],
+        )
+        annotated = [b for b in blocks if "entry_index" in b]
+        self.assertEqual(len(annotated), 3)
 
 
 if __name__ == "__main__":

--- a/tests/test_entry_annotator.py
+++ b/tests/test_entry_annotator.py
@@ -125,5 +125,132 @@ class EntryWithStatblockBaselineDriftTests(unittest.TestCase):
         self.assertEqual(result[0].get("entry_role"), "title")
 
 
+CONDITION_CFG = ContentTypeConfig(
+    name="condition", category="Conditions", chunk_type="condition_entry",
+    shape="definition_list",
+    shape_params={
+        "min_blocks": 3,
+        "term_pattern": r"^[A-Z][\w '/-]*:\s+\S",
+    },
+    file_match=["AbilitiesandConditions.rtf"],
+)
+
+
+class DefinitionListTests(unittest.TestCase):
+    def test_three_conditions_detected(self) -> None:
+        blocks = [
+            _block("Blinded: cannot see", font_size=20, starts_with_bold=True),
+            _block("Confused: rolls d%",  font_size=20, starts_with_bold=True),
+            _block("Dazed: unable to act", font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="AbilitiesandConditions.rtf", content_types=[CONDITION_CFG])
+        roles = [b.get("entry_role") for b in result]
+        self.assertEqual(roles, ["definition", "definition", "definition"])
+        titles = [b["entry_title"] for b in result]
+        self.assertEqual(titles, ["Blinded", "Confused", "Dazed"])
+        indices = [b["entry_index"] for b in result]
+        self.assertEqual(indices, [0, 1, 2])
+
+    def test_below_min_blocks(self) -> None:
+        blocks = [
+            _block("Blinded: cannot see", font_size=20, starts_with_bold=True),
+            _block("Confused: rolls d%",  font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="AbilitiesandConditions.rtf", content_types=[CONDITION_CFG])
+        self.assertTrue(all("entry_index" not in b for b in result))
+
+    def test_size_change_breaks_run(self) -> None:
+        blocks = [
+            _block("Blinded: cannot see", font_size=20, starts_with_bold=True),
+            _block("Confused: rolls d%",  font_size=20, starts_with_bold=True),
+            _block("Dazed: unable to act", font_size=18, starts_with_bold=True),  # different size
+            _block("Frightened: flee",    font_size=18, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="AbilitiesandConditions.rtf", content_types=[CONDITION_CFG])
+        # First run: 2 blocks at fs20 (below min_blocks=3) → no annotation
+        # Second run: 2 blocks at fs18 (below min_blocks=3) → no annotation
+        self.assertTrue(all("entry_index" not in b for b in result))
+
+
+class ConflictTests(unittest.TestCase):
+    def test_re_run_raises(self) -> None:
+        blocks = [
+            _block("Sanctuary",        font_size=24),
+            _block("Abjuration",       font_size=20),
+            _block("Level: Clr 1",     font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+        ]
+        annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        with self.assertRaises(EntryAnnotationConflict):
+            annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+
+    def test_overlapping_matches_raise(self) -> None:
+        # Construct a degenerate case where two configs both match the same range.
+        spell_loose = ContentTypeConfig(
+            name="spell_loose", category="Spells", chunk_type="spell_entry",
+            shape="entry_with_statblock",
+            shape_params={
+                "max_title_len": 80, "max_subtitle_len": 80,
+                "min_fields": 1, "field_pattern": r"^[A-Z][\w '/-]+:",
+            },
+            file_match=None,
+        )
+        spell_loose_b = ContentTypeConfig(
+            name="spell_loose_b", category="Spells", chunk_type="spell_entry",
+            shape="entry_with_statblock",
+            shape_params={
+                "max_title_len": 80, "max_subtitle_len": 80,
+                "min_fields": 1, "field_pattern": r"^[A-Z][\w '/-]+:",
+            },
+            file_match=None,
+        )
+        blocks = [
+            _block("Sanctuary",     font_size=24),
+            _block("Abjuration",    font_size=20),
+            _block("Level: Clr 1",  font_size=20, starts_with_bold=True),
+        ]
+        with self.assertRaises(EntryAnnotationConflict):
+            annotate_entries(blocks, file_name="any.rtf", content_types=[spell_loose, spell_loose_b])
+
+
+class EligibilityTests(unittest.TestCase):
+    def test_excluded_type_does_not_run(self) -> None:
+        # Spell config restricted to Spells*.rtf; the file doesn't match.
+        blocks = [
+            _block("Sanctuary",     font_size=24),
+            _block("Abjuration",    font_size=20),
+            _block("Level: Clr 1",  font_size=20, starts_with_bold=True),
+            _block("Components: V", font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="Description.rtf", content_types=[SPELL_CFG])
+        self.assertTrue(all("entry_index" not in b for b in result))
+
+
+class MultiTypeOverlapTests(unittest.TestCase):
+    def test_description_region_overlapping_other_type_raises(self) -> None:
+        # Spell entry's description region (blocks 4-6 — there's no next
+        # entry title in this file) overlaps with the condition
+        # definition_list match starting at block 4. Both types eligible
+        # because file_name matches the spell file_match glob.
+        spell = SPELL_CFG  # file_match=["Spells*.rtf"]
+        cond = ContentTypeConfig(
+            name="condition", category="Conditions", chunk_type="condition_entry",
+            shape="definition_list",
+            shape_params={"min_blocks": 3, "term_pattern": r"^[A-Z][\w '/-]*:\s+\S"},
+            file_match=None,  # always eligible
+        )
+        blocks = [
+            _block("Sanctuary",        font_size=24),
+            _block("Abjuration",       font_size=20),
+            _block("Level: Clr 1",     font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+            _block("Blinded: cannot see", font_size=18, starts_with_bold=True),
+            _block("Confused: rolls d%",  font_size=18, starts_with_bold=True),
+            _block("Dazed: unable to act", font_size=18, starts_with_bold=True),
+        ]
+        with self.assertRaises(EntryAnnotationConflict):
+            annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[spell, cond])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_entry_annotator.py
+++ b/tests/test_entry_annotator.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.ingest_srd35.content_types import ContentTypeConfig
+from scripts.ingest_srd35.entry_annotator import (
+    annotate_entries,
+    EntryAnnotationConflict,
+)
+
+
+SPELL_CFG = ContentTypeConfig(
+    name="spell", category="Spells", chunk_type="spell_entry",
+    shape="entry_with_statblock",
+    shape_params={
+        "max_title_len": 80, "max_subtitle_len": 80,
+        "min_fields": 2, "field_pattern": r"^[A-Z][\w '/-]+:",
+    },
+    file_match=["Spells*.rtf"],
+)
+
+
+def _block(text: str, *, font_size: int, starts_with_bold: bool = False, all_bold: bool = False) -> dict:
+    return {
+        "block_id": f"b{abs(hash(text)) % 10000:04d}",
+        "block_type": "paragraph",
+        "text": text,
+        "font_size": font_size,
+        "starts_with_bold": starts_with_bold,
+        "all_bold": all_bold,
+    }
+
+
+class EntryWithStatblockHappyPathTests(unittest.TestCase):
+    def test_single_spell_detected(self) -> None:
+        blocks = [
+            _block("Sanctuary",          font_size=24),
+            _block("Abjuration",         font_size=20),
+            _block("Level: Clr 1",       font_size=20, starts_with_bold=True),
+            _block("Components: V, S",   font_size=20, starts_with_bold=True),
+            _block("Description text.",  font_size=24),
+        ]
+        result = annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        roles = [b.get("entry_role") for b in result]
+        self.assertEqual(roles, ["title", "subtitle", "stat_field", "stat_field", "description"])
+        for b in result:
+            self.assertEqual(b["entry_index"], 0)
+            self.assertEqual(b["entry_type"], "spell")
+            self.assertEqual(b["entry_category"], "Spells")
+            self.assertEqual(b["entry_chunk_type"], "spell_entry")
+            self.assertEqual(b["entry_title"], "Sanctuary")
+
+    def test_two_spells_distinct_indices(self) -> None:
+        blocks = [
+            _block("Sanctuary",        font_size=24),
+            _block("Abjuration",       font_size=20),
+            _block("Level: Clr 1",     font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+            _block("Scare",            font_size=24),
+            _block("Necromancy",       font_size=20),
+            _block("Level: Brd 2",     font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        indices = [b["entry_index"] for b in result]
+        self.assertEqual(indices, [0, 0, 0, 0, 1, 1, 1, 1])
+        titles = {b["entry_title"] for b in result}
+        self.assertEqual(titles, {"Sanctuary", "Scare"})
+
+
+class EntryWithStatblockGuardTests(unittest.TestCase):
+    def test_subtitle_same_size_as_title_rejected(self) -> None:
+        blocks = [
+            _block("Looks Like Title", font_size=20),
+            _block("Abjuration",       font_size=20),
+            _block("Level: Clr 1",     font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        self.assertTrue(all("entry_index" not in b for b in result))
+
+    def test_below_min_fields(self) -> None:
+        blocks = [
+            _block("Sanctuary",   font_size=24),
+            _block("Abjuration",  font_size=20),
+            _block("Level: Clr 1", font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        self.assertTrue(all("entry_index" not in b for b in result))
+
+    def test_title_matching_field_pattern_rejected(self) -> None:
+        blocks = [
+            _block("Looking Like: A Field", font_size=24),  # matches field_pattern
+            _block("Abjuration",            font_size=20),
+            _block("Level: Clr 1",          font_size=20, starts_with_bold=True),
+            _block("Components: V, S",      font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        self.assertTrue(all("entry_index" not in b for b in result))
+
+    def test_empty_title_rejected(self) -> None:
+        blocks = [
+            _block("   ",                font_size=24),
+            _block("Abjuration",         font_size=20),
+            _block("Level: Clr 1",       font_size=20, starts_with_bold=True),
+            _block("Components: V, S",   font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        self.assertTrue(all("entry_index" not in b for b in result))
+
+
+class EntryWithStatblockBaselineDriftTests(unittest.TestCase):
+    """Verify shape rule is robust to per-document font baseline drift."""
+    def test_works_when_stat_blocks_dominate(self) -> None:
+        # In a stat-block-heavy file, the IR baseline might be fs20, not fs24.
+        # The shape rule should still match because it uses relational
+        # predicates (subtitle.font_size < title.font_size), not absolute classes.
+        blocks = [
+            _block("Sanctuary",        font_size=24),  # title (larger than subtitle)
+            _block("Abjuration",       font_size=20),  # subtitle
+            _block("Level: Clr 1",     font_size=20, starts_with_bold=True),
+            _block("Components: V, S", font_size=20, starts_with_bold=True),
+        ]
+        result = annotate_entries(blocks, file_name="SpellsS.rtf", content_types=[SPELL_CFG])
+        self.assertEqual(result[0].get("entry_role"), "title")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Part **2 of 4** in the chunker rewrite. Builds the entry detection module as a standalone foundation. **Pipeline behavior unchanged — annotator is built but not yet wired in** (that's PR 3).

**Stacked on #75 (PR 1).** Merge PR 1 first.

### What this PR adds
- `configs/content_types.yaml` + `schemas/content_types.schema.json` — declarative content-type registry binding semantic identity (category, chunk_type) to a shape family + parameters. 3 seed types: spell, feat, condition.
- `scripts/ingest_srd35/content_types.py` — `ContentTypeConfig` frozen dataclass + YAML loader + `eligible_types_for_file()` (fnmatch-glob).
- `scripts/ingest_srd35/entry_annotator.py` — `annotate_entries(blocks, *, file_name, content_types)` public API + private `entry_with_statblock` and `definition_list` shape rules + `EntryAnnotationConflict` exception.
- Vocabulary-free, formatting-driven detection. Title/subtitle/field predicates are **relational** (subtitle smaller than title, fields same size as subtitle) — robust to per-document baseline drift.
- Strict conflict semantics: raises on overlapping shape claims OR re-annotation.

### Why
PR #63 (rolled back) used hardcoded vocabulary lists (`_SCHOOLS = {"Abjuration", ...}`, `_FEAT_TAGS`, `_KNOWN_CONDITIONS`). This PR replaces that approach with shape-driven detection that works across editions/sources without code changes — adding 5e support is a config edit, not a code edit.

### Spec & plan
- Design: `docs/plans/2026-04-23-chunker-rewrite-formatting-aware-design.md` §4.3
- Plan: `docs/plans/2026-04-23-chunker-rewrite-formatting-aware-implementation.md` PR 2 (Tasks 6–10)

### Test plan
- [x] `test_content_types.py` (7 tests): YAML loading, glob matching, schema validation of shipped config.
- [x] `test_entry_annotator.py` (14 tests): both shapes' happy paths + guards + relational predicates + baseline drift; conflict (overlap + re-run) + eligibility + multi-type overlap.
- [x] All 208 tests pass; pipeline does not import annotator (verified via grep).
- [x] One plan-supplied test (`test_two_disjoke_types_coexist`) was renamed and reframed during implementation — the original assertion didn't actually trigger conflict because of file_match filtering. Renamed to `MultiTypeOverlapTests::test_description_region_overlapping_other_type_raises` and switched filename to match the spell glob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)