### PR TITLE
feat(ingestion): pipeline integration — entry-bearing canonical docs (#60 part 3/4)

### DIFF
--- a/configs/bootstrap_sources/srd_35.manifest.json
+++ b/configs/bootstrap_sources/srd_35.manifest.json
@@ -36,6 +36,12 @@
     "style": "source_location",
     "bootstrap_rule": "Use source-native file names plus section or entry paths. Do not invent page references for this source."
   },
+  "boilerplate_phrases": [
+    "visit",
+    "www.wizards.com",
+    "system reference document",
+    "contains all of the"
+  ],
   "provenance_notes": [
     "The committed repo tracks the manifest and fetch workflow only. Raw SRD files remain local and untracked under data/raw/srd_35/.",
     "This bootstrap slice uses an archived distribution source rather than a live Wizards-hosted endpoint.",

--- a/configs/content_types.yaml
+++ b/configs/content_types.yaml
@@ -29,6 +29,7 @@ content_types:
       field_pattern: "^[A-Z][\\w '/-]+:"
     file_match:
       - "Feats.rtf"
+      - "FeatsExcerpt.rtf"
       - "EpicFeats.rtf"
       - "DivineAbilitiesandFeats.rtf"
 
@@ -41,3 +42,4 @@ content_types:
       term_pattern: "^[A-Z][\\w '/-]*:\\s+\\S"
     file_match:
       - "AbilitiesandConditions.rtf"
+      - "ConditionsExcerpt.rtf"

--- a/schemas/canonical_document.schema.json
+++ b/schemas/canonical_document.schema.json
@@ -41,6 +41,32 @@
       "type": "string",
       "format": "date-time",
       "description": "ISO 8601 timestamp of when this document was produced"
+    },
+    "processing_hints": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional pipeline-internal handoffs from ingestion to chunker. Not citation/provenance metadata.",
+      "properties": {
+        "chunk_type_hint": {
+          "type": "string",
+          "enum": ["spell_entry", "feat_entry", "skill_entry", "condition_entry", "class_feature", "glossary_entry"],
+          "description": "Pre-computed chunk_type for the parent chunk; chunker uses this in lieu of heuristic classification"
+        },
+        "structure_cuts": {
+          "type": "array",
+          "description": "Ordered list of structural splits in content. Chunker slices content at these char offsets to produce typed children.",
+          "items": {
+            "type": "object",
+            "required": ["kind", "char_offset", "child_chunk_type"],
+            "additionalProperties": false,
+            "properties": {
+              "kind": {"enum": ["stat_block_end"]},
+              "char_offset": {"type": "integer", "minimum": 0},
+              "child_chunk_type": {"enum": ["stat_block"]}
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/scripts/ingest_srd35/boundary_filter.py
+++ b/scripts/ingest_srd35/boundary_filter.py
@@ -140,13 +140,29 @@ def apply_boundary_filters(
     for index, candidate in enumerate(candidates):
         title = candidate["section_title"].strip()
 
-        # Entry-annotated sections accepted unconditionally.
+        # Entry-annotated sections accepted unconditionally. A pending
+        # forward_merge_bucket (e.g., file-opener boilerplate that was
+        # marked for forward merging) must NOT prepend into the entry —
+        # that would pollute the entry's content and shift downstream
+        # structure_cuts offsets. Promote the bucket to a standalone
+        # non-entry section ahead of the entry instead.
         if "entry_metadata" in candidate:
+            if forward_merge_bucket is not None:
+                accepted.append(forward_merge_bucket)
+                decisions.append(
+                    {
+                        "candidate_index": index + 1,
+                        "title": forward_merge_bucket["section_title"],
+                        "action": "accepted",
+                        "reason_code": "forward_bucket_promoted_before_entry",
+                        "body_char_count": forward_merge_bucket["body_char_count"],
+                        "block_start_id": forward_merge_bucket.get("block_start_id"),
+                        "block_end_id": forward_merge_bucket.get("block_end_id"),
+                    }
+                )
+                forward_merge_bucket = None
             materialized = dict(candidate)
             materialized["block_type_counts"] = dict(candidate.get("block_type_counts", {}))
-            if forward_merge_bucket is not None:
-                _prepend_section(materialized, forward_merge_bucket)
-                forward_merge_bucket = None
             accepted.append(materialized)
             decisions.append(
                 {

--- a/scripts/ingest_srd35/boundary_filter.py
+++ b/scripts/ingest_srd35/boundary_filter.py
@@ -10,9 +10,31 @@ TRUNCATED_TITLE_SUFFIXES = {"and", "or", "the", "of", "to", "for", "a", "an"}
 
 
 # Boilerplate phrases now come from the per-source manifest at call time.
-# _SPELL_BLOCK_FIELDS and _looks_spell_block_field() are removed; entry
-# detection upstream tags stat-block field lines so they never reach the
-# boundary filter as candidates.
+# Stat-field-lookalike detection: vocabulary-free formatting check using the
+# section's title block formatting (starts_with_bold + short Word: shape).
+# Catches the case where the heading-candidate sectioner promoted a bold
+# stat-field line to a section title in files where the entry annotator
+# didn't fire.
+_FIELD_LIKE_TITLE_RE = re.compile(r"^[A-Z][\w '/-]+:\s*\S?")
+
+
+def _looks_stat_field_lookalike(candidate: dict) -> bool:
+    """Return True when a candidate title looks like a bold-prefixed stat
+    block field that the heading-candidate path mistakenly promoted to a
+    section title (e.g., \"Components: V, S, M\").
+
+    This is the formatting-driven replacement for the deleted vocabulary
+    list `_SPELL_BLOCK_FIELDS`. Only fires when the title block is bold
+    AND short AND matches the generic Word:value pattern — works across
+    editions/sources because it relies on the encoding shape, not specific
+    field names.
+    """
+    if not candidate.get("title_starts_with_bold", False):
+        return False
+    title = candidate["section_title"].strip()
+    if len(title) > 80:
+        return False
+    return bool(_FIELD_LIKE_TITLE_RE.match(title))
 
 
 def _looks_truncated_title(title: str) -> bool:
@@ -148,6 +170,9 @@ def apply_boundary_filters(
         elif _looks_table_label_title(title):
             action = "merged_backward" if accepted else "merged_forward"
             reason_code = "table_label_title"
+        elif _looks_stat_field_lookalike(candidate):
+            action = "merged_backward" if accepted else "merged_forward"
+            reason_code = "stat_field_lookalike"
         elif _is_table_fragment(candidate):
             action = "merged_backward" if accepted else "merged_forward"
             reason_code = "table_fragment_section"

--- a/scripts/ingest_srd35/boundary_filter.py
+++ b/scripts/ingest_srd35/boundary_filter.py
@@ -6,31 +6,13 @@ from .sectioning import sanitize_identifier
 
 MIN_SUSPICIOUS_SECTION_CHARS = 60
 MIN_KEEP_TABLE_SECTION_PARAGRAPHS = 1
-BOILERPLATE_PHRASES = {
-    "visit",
-    "www.wizards.com",
-    "system reference document",
-    "contains all of the",
-}
 TRUNCATED_TITLE_SUFFIXES = {"and", "or", "the", "of", "to", "for", "a", "an"}
 
-# Spell / power stat-block field names that appear as bold labels in RTF spell entries.
-# These are not independent sections; they should be merged backward into the preceding
-# spell or power entry.
-_SPELL_BLOCK_FIELDS = {
-    "area",
-    "casting time",
-    "component",
-    "components",
-    "duration",
-    "effect",
-    "level",
-    "range",
-    "saving throw",
-    "spell resistance",
-    "target",
-    "targets",
-}
+
+# Boilerplate phrases now come from the per-source manifest at call time.
+# _SPELL_BLOCK_FIELDS and _looks_spell_block_field() are removed; entry
+# detection upstream tags stat-block field lines so they never reach the
+# boundary filter as candidates.
 
 
 def _looks_truncated_title(title: str) -> bool:
@@ -59,27 +41,18 @@ def _looks_table_label_title(title: str) -> bool:
     return "|" in title or title.strip().lower().startswith("table:")
 
 
-def _looks_spell_block_field(title: str) -> bool:
-    """Return True when a candidate title is a spell/power stat-block field label.
-
-    Spell entries in RTF files format their stat fields (Components, Range,
-    Duration, etc.) with bold text, which the section detector may pick up as
-    heading candidates.  These lines are not independent sections; they belong
-    to the preceding spell or power entry.
-    """
-    if ":" not in title:
-        return False
-    field = title.split(":")[0].strip().lower()
-    return field in _SPELL_BLOCK_FIELDS
-
-
-def _is_boilerplate_stub(candidate: dict, file_stem: str, source_file_name: str) -> bool:
+def _is_boilerplate_stub(
+    candidate: dict,
+    file_stem: str,
+    source_file_name: str,
+    boilerplate_phrases: set[str],
+) -> bool:
     if source_file_name.lower() == "legal.rtf":
         return False
     content = candidate["content"].lower()
     if candidate["body_char_count"] > 220:
         return False
-    has_phrase = any(phrase in content for phrase in BOILERPLATE_PHRASES)
+    has_phrase = any(phrase in content for phrase in boilerplate_phrases)
     if sanitize_identifier(candidate["section_title"]) == sanitize_identifier(file_stem):
         return has_phrase or candidate["body_char_count"] < 40
     return has_phrase
@@ -112,7 +85,15 @@ def _prepend_section(target: dict, incoming: dict) -> None:
         target["block_type_counts"][key] = target["block_type_counts"].get(key, 0) + value
 
 
-def apply_boundary_filters(file_stem: str, source_file_name: str, candidates: list[dict]) -> tuple[list[dict], list[dict]]:
+def apply_boundary_filters(
+    file_stem: str,
+    source_file_name: str,
+    candidates: list[dict],
+    *,
+    boilerplate_phrases: set[str] | None = None,
+) -> tuple[list[dict], list[dict]]:
+    boilerplate_phrases = boilerplate_phrases or set()
+
     if source_file_name.lower() == "legal.rtf":
         return (
             [dict(candidate) for candidate in candidates],
@@ -136,18 +117,37 @@ def apply_boundary_filters(file_stem: str, source_file_name: str, candidates: li
 
     for index, candidate in enumerate(candidates):
         title = candidate["section_title"].strip()
+
+        # Entry-annotated sections accepted unconditionally.
+        if "entry_metadata" in candidate:
+            materialized = dict(candidate)
+            materialized["block_type_counts"] = dict(candidate.get("block_type_counts", {}))
+            if forward_merge_bucket is not None:
+                _prepend_section(materialized, forward_merge_bucket)
+                forward_merge_bucket = None
+            accepted.append(materialized)
+            decisions.append(
+                {
+                    "candidate_index": index + 1,
+                    "title": title,
+                    "action": "accepted",
+                    "reason_code": "entry_annotated",
+                    "body_char_count": candidate["body_char_count"],
+                    "block_start_id": candidate.get("block_start_id"),
+                    "block_end_id": candidate.get("block_end_id"),
+                }
+            )
+            continue
+
         reason_code = "accepted_clean"
         action = "accepted"
 
-        if index == 0 and _is_boilerplate_stub(candidate, file_stem, source_file_name):
+        if index == 0 and _is_boilerplate_stub(candidate, file_stem, source_file_name, boilerplate_phrases):
             action = "merged_forward" if len(candidates) > 1 else "dropped"
             reason_code = "boilerplate_opener_stub"
         elif _looks_table_label_title(title):
             action = "merged_backward" if accepted else "merged_forward"
             reason_code = "table_label_title"
-        elif _looks_spell_block_field(title):
-            action = "merged_backward" if accepted else "merged_forward"
-            reason_code = "spell_block_field"
         elif _is_table_fragment(candidate):
             action = "merged_backward" if accepted else "merged_forward"
             reason_code = "table_fragment_section"

--- a/scripts/ingest_srd35/pipeline.py
+++ b/scripts/ingest_srd35/pipeline.py
@@ -111,6 +111,7 @@ def ingest_source(
     canonical_records: list[dict] = []
     canonical_docs: list[dict] | None = [] if require_schema_validation else None
     demote_heading_candidate_files = set(manifest.get("fixture_overrides", {}).get("demote_heading_candidate_files", []))
+    boilerplate_phrases = set(manifest.get("boilerplate_phrases", []))
 
     for rtf_path in rtf_files:
         raw_bytes = rtf_path.read_bytes()
@@ -133,7 +134,12 @@ def ingest_source(
         extracted_ir_path.write_text(json.dumps(extraction_ir, indent=2) + "\n", encoding="utf-8")
 
         section_candidates = split_sections_from_blocks(rtf_path.stem, extraction_ir["blocks"])
-        sections, boundary_decisions = apply_boundary_filters(rtf_path.stem, rtf_path.name, section_candidates)
+        sections, boundary_decisions = apply_boundary_filters(
+            rtf_path.stem,
+            rtf_path.name,
+            section_candidates,
+            boilerplate_phrases=boilerplate_phrases,
+        )
         for index, section in enumerate(sections, start=1):
             section_slug = section["section_slug"]
             section_title = section["section_title"]

--- a/scripts/ingest_srd35/pipeline.py
+++ b/scripts/ingest_srd35/pipeline.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from .boundary_filter import apply_boundary_filters
 from .constants import EXTRACTION_CAVEATS, INGESTION_NOTES
-from .content_types import load_content_types
+from .content_types import eligible_types_for_file, load_content_types
 from .entry_annotator import annotate_entries
 from .extraction_ir import build_extraction_ir
 from .paths import remove_directory_if_present, resolve_repo_relative_path
@@ -103,6 +103,7 @@ def _write_reports(
     ingested_at: str,
     extraction_records: list[dict],
     canonical_records: list[dict],
+    entry_annotation_summary: dict | None = None,
 ) -> tuple[Path, Path]:
     extracted_report = {
         "source_id": manifest["source_id"],
@@ -124,6 +125,8 @@ def _write_reports(
         "extraction_caveats": EXTRACTION_CAVEATS,
         "records": canonical_records,
     }
+    if entry_annotation_summary is not None:
+        canonical_report["entry_annotation_summary"] = entry_annotation_summary
     canonical_report_path = canonical_root / "canonical_report.json"
     canonical_report_path.write_text(json.dumps(canonical_report, indent=2) + "\n", encoding="utf-8")
     return extracted_report_path, canonical_report_path
@@ -177,6 +180,14 @@ def ingest_source(
     else:
         content_types = []
 
+    entry_annotation_summary: dict = {
+        "files_with_entries": 0,
+        "files_passthrough_no_eligible_type": 0,
+        "files_passthrough_no_shape_match": 0,
+        "entries_by_type": {},
+        "shape_match_failures": [],
+    }
+
     for rtf_path in rtf_files:
         raw_bytes = rtf_path.read_bytes()
         rtf_text = raw_bytes.decode("latin-1", errors="ignore")
@@ -199,6 +210,31 @@ def ingest_source(
             file_name=rtf_path.name,
             content_types=content_types,
         )
+
+        eligible = eligible_types_for_file(rtf_path.name, content_types)
+        file_has_entries = any("entry_index" in b for b in extraction_ir["blocks"])
+        if not eligible:
+            entry_annotation_summary["files_passthrough_no_eligible_type"] += 1
+        elif not file_has_entries:
+            entry_annotation_summary["files_passthrough_no_shape_match"] += 1
+            for cfg in eligible:
+                entry_annotation_summary["shape_match_failures"].append({
+                    "file": rtf_path.name,
+                    "type": cfg.name,
+                    "reason": "no_match",
+                })
+        else:
+            entry_annotation_summary["files_with_entries"] += 1
+            type_counts: dict[str, int] = {}
+            for b in extraction_ir["blocks"]:
+                et = b.get("entry_type")
+                if et is not None and b.get("entry_role") in ("title", "definition"):
+                    type_counts[et] = type_counts.get(et, 0) + 1
+            for type_name, count in type_counts.items():
+                entry_annotation_summary["entries_by_type"][type_name] = (
+                    entry_annotation_summary["entries_by_type"].get(type_name, 0) + count
+                )
+
         extracted_ir_path = extracted_ir_root / f"{file_slug}.json"
         extracted_ir_path.write_text(json.dumps(extraction_ir, indent=2) + "\n", encoding="utf-8")
 
@@ -285,6 +321,7 @@ def ingest_source(
         ingested_at=ingested_at,
         extraction_records=extraction_records,
         canonical_records=canonical_records,
+        entry_annotation_summary=entry_annotation_summary,
     )
     return {
         "source_id": manifest["source_id"],

--- a/scripts/ingest_srd35/pipeline.py
+++ b/scripts/ingest_srd35/pipeline.py
@@ -40,56 +40,24 @@ def build_source_ref(manifest: dict) -> dict:
 def _compute_processing_hints(section: dict, meta: dict) -> dict:
     """Build processing_hints dict from section + entry_metadata.
 
-    Currently emits chunk_type_hint plus structure_cuts (only for
-    entry_with_statblock shape — definition_list entries are single-block
-    and need no cuts).
+    Reads stat_block_end_char directly from entry_metadata when the
+    sectioner stamped it (entry_with_statblock shape). No content
+    re-scan — sectioning already computed the offset from block roles
+    so it's stable against content normalization, prepended forward
+    buckets, or description first-lines that happen to match the field
+    pattern. definition_list entries are single-block and emit no cuts.
     """
     hints: dict = {"chunk_type_hint": meta["entry_chunk_type"]}
-    if meta["shape_family"] == "entry_with_statblock":
-        cut_offset = _stat_block_end_offset(section)
-        if cut_offset > 0:
-            hints["structure_cuts"] = [
-                {
-                    "kind": "stat_block_end",
-                    "char_offset": cut_offset,
-                    "child_chunk_type": "stat_block",
-                }
-            ]
+    cut_offset = meta.get("stat_block_end_char")
+    if cut_offset and cut_offset > 0:
+        hints["structure_cuts"] = [
+            {
+                "kind": "stat_block_end",
+                "char_offset": cut_offset,
+                "child_chunk_type": "stat_block",
+            }
+        ]
     return hints
-
-
-_STAT_FIELD_LINE_RE = re.compile(r"^[A-Z][\w '/-]+:")
-
-
-def _stat_block_end_offset(section: dict) -> int:
-    """Compute the char offset in section['content'] just past the last
-    consecutive stat-field line (as would have been tagged stat_field
-    upstream by the entry annotator).
-
-    Section content is "\\n".join(block.text.strip() for blocks in the
-    section). We walk the content lines to find the last consecutive line
-    matching the field pattern. The annotator already validated these are
-    stat fields; here we only need to find where the block ends to
-    compute the cut offset.
-    """
-    content = section["content"]
-    lines = content.split("\n")
-    last_field_line = -1
-    for i, line in enumerate(lines):
-        if _STAT_FIELD_LINE_RE.match(line):
-            last_field_line = i
-        elif last_field_line >= 0:
-            break
-    if last_field_line < 0:
-        return 0
-    # Offset = sum of line lengths through last field line + the "\n"
-    # separators between them.
-    offset = sum(len(lines[i]) for i in range(last_field_line + 1)) + last_field_line
-    # Plus one more for the newline after the last field line if any
-    # content follows.
-    if last_field_line + 1 < len(lines):
-        offset += 1
-    return offset
 
 
 def _write_reports(

--- a/scripts/ingest_srd35/pipeline.py
+++ b/scripts/ingest_srd35/pipeline.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
 from .boundary_filter import apply_boundary_filters
 from .constants import EXTRACTION_CAVEATS, INGESTION_NOTES
+from .content_types import load_content_types
+from .entry_annotator import annotate_entries
 from .extraction_ir import build_extraction_ir
 from .paths import remove_directory_if_present, resolve_repo_relative_path
 from .rtf_decoder import decode_rtf_spans, decode_rtf_text
@@ -32,6 +35,61 @@ def build_source_ref(manifest: dict) -> dict:
         "source_type": manifest["source_type"],
         "authority_level": manifest["authority_level"],
     }
+
+
+def _compute_processing_hints(section: dict, meta: dict) -> dict:
+    """Build processing_hints dict from section + entry_metadata.
+
+    Currently emits chunk_type_hint plus structure_cuts (only for
+    entry_with_statblock shape — definition_list entries are single-block
+    and need no cuts).
+    """
+    hints: dict = {"chunk_type_hint": meta["entry_chunk_type"]}
+    if meta["shape_family"] == "entry_with_statblock":
+        cut_offset = _stat_block_end_offset(section)
+        if cut_offset > 0:
+            hints["structure_cuts"] = [
+                {
+                    "kind": "stat_block_end",
+                    "char_offset": cut_offset,
+                    "child_chunk_type": "stat_block",
+                }
+            ]
+    return hints
+
+
+_STAT_FIELD_LINE_RE = re.compile(r"^[A-Z][\w '/-]+:")
+
+
+def _stat_block_end_offset(section: dict) -> int:
+    """Compute the char offset in section['content'] just past the last
+    consecutive stat-field line (as would have been tagged stat_field
+    upstream by the entry annotator).
+
+    Section content is "\\n".join(block.text.strip() for blocks in the
+    section). We walk the content lines to find the last consecutive line
+    matching the field pattern. The annotator already validated these are
+    stat fields; here we only need to find where the block ends to
+    compute the cut offset.
+    """
+    content = section["content"]
+    lines = content.split("\n")
+    last_field_line = -1
+    for i, line in enumerate(lines):
+        if _STAT_FIELD_LINE_RE.match(line):
+            last_field_line = i
+        elif last_field_line >= 0:
+            break
+    if last_field_line < 0:
+        return 0
+    # Offset = sum of line lengths through last field line + the "\n"
+    # separators between them.
+    offset = sum(len(lines[i]) for i in range(last_field_line + 1)) + last_field_line
+    # Plus one more for the newline after the last field line if any
+    # content follows.
+    if last_field_line + 1 < len(lines):
+        offset += 1
+    return offset
 
 
 def _write_reports(
@@ -113,6 +171,12 @@ def ingest_source(
     demote_heading_candidate_files = set(manifest.get("fixture_overrides", {}).get("demote_heading_candidate_files", []))
     boilerplate_phrases = set(manifest.get("boilerplate_phrases", []))
 
+    content_types_path = repo_root / "configs" / "content_types.yaml"
+    if content_types_path.exists():
+        content_types = load_content_types(content_types_path.read_text(encoding="utf-8"))
+    else:
+        content_types = []
+
     for rtf_path in rtf_files:
         raw_bytes = rtf_path.read_bytes()
         rtf_text = raw_bytes.decode("latin-1", errors="ignore")
@@ -130,6 +194,11 @@ def ingest_source(
             for block in extraction_ir["blocks"]:
                 if block.get("block_type") == "heading_candidate":
                     block["block_type"] = "paragraph"
+        annotate_entries(
+            extraction_ir["blocks"],
+            file_name=rtf_path.name,
+            content_types=content_types,
+        )
         extracted_ir_path = extracted_ir_root / f"{file_slug}.json"
         extracted_ir_path.write_text(json.dumps(extraction_ir, indent=2) + "\n", encoding="utf-8")
 
@@ -144,18 +213,36 @@ def ingest_source(
             section_slug = section["section_slug"]
             section_title = section["section_title"]
             source_location = f"{source_location_base}#{index:03d}_{section_slug}"
-            section_path = [rtf_path.stem, section_title]
+
+            meta = section.get("entry_metadata")
+            if meta:
+                section_path = [meta["entry_category"], meta["entry_title"]]
+                document_title = meta["entry_title"]
+                locator: dict = {
+                    "section_path": section_path,
+                    "source_location": source_location,
+                    "entry_title": meta["entry_title"],
+                }
+            else:
+                section_path = [rtf_path.stem, section_title]
+                document_title = section_title
+                locator = {"section_path": section_path, "source_location": source_location}
+
             document_id = f"{manifest['source_id']}::{file_slug}::{index:03d}_{section_slug}"
 
-            canonical_doc = {
+            canonical_doc: dict = {
                 "document_id": document_id,
                 "source_ref": source_ref,
-                "locator": {"section_path": section_path, "source_location": source_location},
+                "locator": locator,
                 "content": section["content"],
-                "document_title": section_title,
+                "document_title": document_title,
                 "source_checksum": raw_checksum,
                 "ingested_at": ingested_at,
             }
+
+            if meta:
+                canonical_doc["processing_hints"] = _compute_processing_hints(section, meta)
+
             if canonical_docs is not None:
                 canonical_docs.append(canonical_doc)
 

--- a/scripts/ingest_srd35/sectioning.py
+++ b/scripts/ingest_srd35/sectioning.py
@@ -31,6 +31,24 @@ def looks_like_heading(line: str) -> bool:
 
 
 def split_sections_from_blocks(file_stem: str, blocks: list[dict]) -> list[dict]:
+    """Two-path sectioning.
+
+    If ANY block carries entry_index, use the entry-driven path:
+      - Group blocks by entry_index (one section per entry).
+      - Run unannotated gap blocks through _sections_from_heading_candidates.
+    Otherwise, use today's heading-candidate behavior on all blocks.
+    """
+    has_annotations = any("entry_index" in b for b in blocks)
+    if not has_annotations:
+        return _sections_from_heading_candidates(file_stem, blocks)
+    return _sections_with_entries(file_stem, blocks)
+
+
+# ----------------------------------------------------------------------
+# Heading-candidate path (today's logic, lifted into a helper)
+# ----------------------------------------------------------------------
+
+def _sections_from_heading_candidates(file_stem: str, blocks: list[dict]) -> list[dict]:
     sections: list[dict] = []
     current_title = file_stem
     current_block_indices: list[int] = []
@@ -133,6 +151,69 @@ def split_sections_from_blocks(file_stem: str, blocks: list[dict]) -> list[dict]
             }
         )
     return sections
+
+
+# ----------------------------------------------------------------------
+# Entry-driven path
+# ----------------------------------------------------------------------
+
+def _sections_with_entries(file_stem: str, blocks: list[dict]) -> list[dict]:
+    """Group annotated blocks by entry_index; gap ranges go through heading-candidate path."""
+    sections: list[dict] = []
+    cursor = 0
+    n = len(blocks)
+    while cursor < n:
+        block = blocks[cursor]
+        if "entry_index" in block:
+            # Collect all consecutive blocks with the SAME entry_index.
+            entry_idx = block["entry_index"]
+            start = cursor
+            while cursor < n and blocks[cursor].get("entry_index") == entry_idx:
+                cursor += 1
+            sections.append(_build_entry_section(blocks, start, cursor))
+        else:
+            # Collect a contiguous gap of unannotated blocks.
+            start = cursor
+            while cursor < n and "entry_index" not in blocks[cursor]:
+                cursor += 1
+            gap_blocks = blocks[start:cursor]
+            sections.extend(_sections_from_heading_candidates(file_stem, gap_blocks))
+    return sections
+
+
+def _build_entry_section(blocks: list[dict], start: int, end: int) -> dict:
+    entry_blocks = blocks[start:end]
+    first = entry_blocks[0]
+    title = first.get("entry_title", first.get("text", "")).strip()
+    content_lines: list[str] = []
+    block_type_counts: dict[str, int] = {}
+    for b in entry_blocks:
+        text = b.get("text", "").strip()
+        if not text:
+            continue
+        content_lines.append(text)
+        bt = b.get("block_type", "paragraph")
+        block_type_counts[bt] = block_type_counts.get(bt, 0) + 1
+    content = "\n".join(content_lines).strip()
+    return {
+        "section_title": title,
+        "section_slug": sanitize_identifier(title),
+        "content": content,
+        "body_char_count": len(content),
+        "block_start_index": start,
+        "block_end_index": end - 1,
+        "block_start_id": entry_blocks[0].get("block_id"),
+        "block_end_id": entry_blocks[-1].get("block_id"),
+        "block_type_counts": block_type_counts,
+        "entry_metadata": {
+            "entry_type": first["entry_type"],
+            "entry_category": first["entry_category"],
+            "entry_chunk_type": first["entry_chunk_type"],
+            "entry_title": title,
+            "entry_index": first["entry_index"],
+            "shape_family": first["shape_family"],
+        },
+    }
 
 
 def split_sections(file_stem: str, text: str) -> list[dict]:

--- a/scripts/ingest_srd35/sectioning.py
+++ b/scripts/ingest_srd35/sectioning.py
@@ -84,6 +84,12 @@ def _sections_from_heading_candidates(file_stem: str, blocks: list[dict]) -> lis
                 "block_start_id": start_block.get("block_id"),
                 "block_end_id": end_block.get("block_id"),
                 "block_type_counts": block_type_counts,
+                # Title block formatting hints (additive optional) — boundary
+                # filter uses these to detect bold-prefixed stat-field
+                # lines that the heading-candidate sectioner mistakenly
+                # promoted to section titles.
+                "title_starts_with_bold": start_block.get("starts_with_bold", False),
+                "title_font_size": start_block.get("font_size", 0),
             }
         )
 

--- a/scripts/ingest_srd35/sectioning.py
+++ b/scripts/ingest_srd35/sectioning.py
@@ -193,14 +193,39 @@ def _build_entry_section(blocks: list[dict], start: int, end: int) -> dict:
     title = first.get("entry_title", first.get("text", "")).strip()
     content_lines: list[str] = []
     block_type_counts: dict[str, int] = {}
-    for b in entry_blocks:
+    # Track the running char offset into the joined content as we
+    # accumulate non-empty blocks. Used to compute stat_block_end_char
+    # offset directly from block roles (instead of a downstream regex
+    # pass over the joined content, which is brittle if any prepend or
+    # text normalization shifts the offset).
+    char_cursor = 0
+    last_stat_field_end_char: int | None = None
+    for idx, b in enumerate(entry_blocks):
         text = b.get("text", "").strip()
         if not text:
             continue
+        if content_lines:
+            char_cursor += 1  # the "\n" join separator
+        char_cursor += len(text)
+        if b.get("entry_role") == "stat_field":
+            last_stat_field_end_char = char_cursor
         content_lines.append(text)
         bt = b.get("block_type", "paragraph")
         block_type_counts[bt] = block_type_counts.get(bt, 0) + 1
     content = "\n".join(content_lines).strip()
+    entry_metadata: dict = {
+        "entry_type": first["entry_type"],
+        "entry_category": first["entry_category"],
+        "entry_chunk_type": first["entry_chunk_type"],
+        "entry_title": title,
+        "entry_index": first["entry_index"],
+        "shape_family": first["shape_family"],
+    }
+    if last_stat_field_end_char is not None:
+        # Block-derived stat-block boundary in joined content. Pipeline
+        # consumes this directly into processing_hints.structure_cuts —
+        # no regex re-scan needed.
+        entry_metadata["stat_block_end_char"] = last_stat_field_end_char
     return {
         "section_title": title,
         "section_slug": sanitize_identifier(title),
@@ -211,14 +236,7 @@ def _build_entry_section(blocks: list[dict], start: int, end: int) -> dict:
         "block_start_id": entry_blocks[0].get("block_id"),
         "block_end_id": entry_blocks[-1].get("block_id"),
         "block_type_counts": block_type_counts,
-        "entry_metadata": {
-            "entry_type": first["entry_type"],
-            "entry_category": first["entry_category"],
-            "entry_chunk_type": first["entry_chunk_type"],
-            "entry_title": title,
-            "entry_index": first["entry_index"],
-            "shape_family": first["shape_family"],
-        },
+        "entry_metadata": entry_metadata,
     }
 
 

--- a/tests/fixtures/srd_35_entries/ConditionsExcerpt.rtf
+++ b/tests/fixtures/srd_35_entries/ConditionsExcerpt.rtf
@@ -1,0 +1,9 @@
+{\rtf1\ansi\deff0{\fonttbl{\f0\froman Times New Roman;}}
+\fs24 CONDITIONS EXCERPT
+\par
+\par {\b\fs20\cf0 Blinded:}{\fs20\cf0  The character cannot see.
+\par }{\b\fs20\cf0 Confused:}{\fs20\cf0  A confused character's actions are determined by rolling d%.
+\par }{\b\fs20\cf0 Dazed:}{\fs20\cf0  The creature is unable to act normally.
+\par }{\b\fs20\cf0 Frightened:}{\fs20\cf0  Flees from the source of fear.
+\par }
+}

--- a/tests/fixtures/srd_35_entries/FeatsExcerpt.rtf
+++ b/tests/fixtures/srd_35_entries/FeatsExcerpt.rtf
@@ -1,0 +1,13 @@
+{\rtf1\ansi\deff0{\fonttbl{\f0\froman Times New Roman;}}
+\fs24 FEATS EXCERPT
+\par {\cf0
+\par ACROBATIC
+\par }{\fs20\cf0 [GENERAL]
+\par }{\b\fs20\cf0 Benefit:}{\fs20\cf0  +2 bonus on Jump and Tumble checks.
+\par }{\cf0
+\par POWER ATTACK
+\par }{\fs20\cf0 [GENERAL]
+\par }{\b\fs20\cf0 Prerequisite:}{\fs20\cf0  Str 13.
+\par }{\b\fs20\cf0 Benefit:}{\fs20\cf0  Subtract from attack, add to damage.
+\par }
+}

--- a/tests/fixtures/srd_35_entries/SpellsExcerpt.rtf
+++ b/tests/fixtures/srd_35_entries/SpellsExcerpt.rtf
@@ -1,0 +1,16 @@
+{\rtf1\ansi\deff0{\fonttbl{\f0\froman Times New Roman;}}
+\fs24 SPELLS EXCERPT
+\par {\cf0
+\par Sanctuary
+\par }{\fs20\cf0 Abjuration
+\par }{\b\fs20\cf0 Level:}{\fs20\cf0  Clr 1
+\par }{\b\fs20\cf0 Components:}{\fs20\cf0  V, S, DF
+\par }{\fs24 Any opponent attempting to strike must save.
+\par
+\par }{\cf0 Scare
+\par }{\fs20\cf0 Necromancy
+\par }{\b\fs20\cf0 Level:}{\fs20\cf0  Brd 2
+\par }{\b\fs20\cf0 Components:}{\fs20\cf0  V, S, M
+\par }{\fs24 This spell functions like cause fear.
+\par }
+}

--- a/tests/test_boundary_filter.py
+++ b/tests/test_boundary_filter.py
@@ -116,6 +116,55 @@ class BoundaryFilterTests(unittest.TestCase):
         accepted, _ = apply_boundary_filters("Races", "Races.rtf", candidates)
         self.assertEqual([section["section_title"] for section in accepted], ["FAVORED CLASS", "HUMANS", "DWARVES"])
 
+    def test_stat_field_lookalike_merged_backward(self) -> None:
+        # Codex P1 regression cover: when entry detection didn't fire on an
+        # eligible spell file, bold-prefixed stat-field lines (Components:,
+        # Effect:, Range:) used to be merged back into the preceding entry
+        # via the deleted _looks_spell_block_field rule. The vocabulary-free
+        # replacement uses formatting (title_starts_with_bold) + generic
+        # Word: shape, which catches the same case without a per-edition
+        # word list.
+        sanctuary = _candidate(
+            "Sanctuary",
+            "Any opponent attempting to strike the warded creature must save." * 3,
+        )
+        sanctuary["title_starts_with_bold"] = False
+        sanctuary["title_font_size"] = 24
+
+        # Title text matches what the sectioner actually produces: when a
+        # heading_candidate block is "Components: V, S, DF", the sectioner
+        # promotes the full block text to section_title.
+        components_field = _candidate("Components: V, S, DF", "V, S, DF")
+        components_field["title_starts_with_bold"] = True
+        components_field["title_font_size"] = 20
+
+        candidates = [sanctuary, components_field]
+        accepted, decisions = apply_boundary_filters(
+            "SpellsS", "SpellsS.rtf", candidates,
+        )
+        self.assertEqual(len(accepted), 1)
+        self.assertIn("V, S, DF", accepted[0]["content"])
+        self.assertEqual(decisions[1]["reason_code"], "stat_field_lookalike")
+        self.assertEqual(decisions[1]["action"], "merged_backward")
+
+    def test_stat_field_lookalike_only_fires_when_title_is_bold(self) -> None:
+        # Same shape but no bold flag — must NOT trigger the new rule
+        # (avoids false positives on regular sections that happen to start
+        # with "Word: ...").
+        components_unbold = _candidate("Components: V, S, DF", "V, S, DF")
+        components_unbold["title_starts_with_bold"] = False
+        components_unbold["title_font_size"] = 20
+
+        accepted, decisions = apply_boundary_filters(
+            "SpellsS", "SpellsS.rtf", [
+                _candidate("Sanctuary", "long body content here." * 10),
+                components_unbold,
+            ],
+        )
+        # Falls through to the suspicious_short_or_truncated branch instead
+        # (since the body is short), but NOT the stat_field_lookalike branch.
+        self.assertNotEqual(decisions[1]["reason_code"], "stat_field_lookalike")
+
     def test_entry_annotated_section_accepted_unconditionally(self) -> None:
         # Entry-annotated sections bypass all heuristics (short body, suspicious title, etc.).
         short_entry = _candidate("Components", "V, S")

--- a/tests/test_boundary_filter.py
+++ b/tests/test_boundary_filter.py
@@ -4,6 +4,14 @@ from scripts.ingest_srd35.boundary_filter import apply_boundary_filters
 from scripts.ingest_srd35.sectioning import sanitize_identifier
 
 
+BOILERPLATE_PHRASES = {
+    "visit",
+    "www.wizards.com",
+    "system reference document",
+    "contains all of the",
+}
+
+
 def _candidate(title: str, content: str, paragraph_count: int = 1, table_rows: int = 0) -> dict:
     return {
         "section_title": title,
@@ -30,7 +38,12 @@ class BoundaryFilterTests(unittest.TestCase):
             _candidate("Description", "This material is Open Game Content. Visit www.wizards.com for details."),
             _candidate("Alignment", "Alignment is a broad category describing ethical outlook."),
         ]
-        accepted, decisions = apply_boundary_filters("Description", "Description.rtf", candidates)
+        accepted, decisions = apply_boundary_filters(
+            "Description",
+            "Description.rtf",
+            candidates,
+            boilerplate_phrases=BOILERPLATE_PHRASES,
+        )
         self.assertEqual(len(accepted), 1)
         self.assertIn("Visit www.wizards.com", accepted[0]["content"])
         self.assertEqual(decisions[0]["action"], "merged_forward")
@@ -40,7 +53,12 @@ class BoundaryFilterTests(unittest.TestCase):
             _candidate("LEGAL INFORMATION", "This legal text is primary content in this source."),
             _candidate("OPEN GAME LICENSE Version 1.0a", "License terms continue here in full detail."),
         ]
-        accepted, decisions = apply_boundary_filters("Legal", "Legal.rtf", candidates)
+        accepted, decisions = apply_boundary_filters(
+            "Legal",
+            "Legal.rtf",
+            candidates,
+            boilerplate_phrases=BOILERPLATE_PHRASES,
+        )
         self.assertEqual(len(accepted), 2)
         self.assertTrue(all(decision["action"] == "accepted" for decision in decisions[:2]))
 
@@ -79,20 +97,6 @@ class BoundaryFilterTests(unittest.TestCase):
         accepted, _ = apply_boundary_filters("Description", "Description.rtf", candidates)
         self.assertEqual([section["section_title"] for section in accepted], ["THE NINE ALIGNMENTS", "AGE"])
 
-    def test_merges_spell_block_field_candidates(self) -> None:
-        # "Components:", "Spell Resistance:", etc. are bold-formatted field labels
-        # inside spell entries — not independent sections.
-        spell_body = "Evocation [Fire]; Level: Sor/Wiz 1; Duration: Instantaneous" * 3
-        candidates = [
-            _candidate("Burning Hands", spell_body),
-            _candidate("Components: V, S", "V, S"),
-            _candidate("Spell Resistance: Yes", "Yes — spell resistance applies."),
-        ]
-        accepted, decisions = apply_boundary_filters("SpellsA-B", "SpellsA-B.rtf", candidates)
-        self.assertEqual(len(accepted), 1)
-        self.assertEqual(decisions[1]["reason_code"], "spell_block_field")
-        self.assertEqual(decisions[2]["reason_code"], "spell_block_field")
-
     def test_merges_named_table_headings(self) -> None:
         # "Table: X" headings (without "|") are table titles, not independent sections.
         candidates = [
@@ -111,6 +115,26 @@ class BoundaryFilterTests(unittest.TestCase):
         ]
         accepted, _ = apply_boundary_filters("Races", "Races.rtf", candidates)
         self.assertEqual([section["section_title"] for section in accepted], ["FAVORED CLASS", "HUMANS", "DWARVES"])
+
+    def test_entry_annotated_section_accepted_unconditionally(self) -> None:
+        # Entry-annotated sections bypass all heuristics (short body, suspicious title, etc.).
+        short_entry = _candidate("Components", "V, S")
+        short_entry["entry_metadata"] = {
+            "entry_type": "spell",
+            "entry_category": "spell",
+            "entry_chunk_type": "spell_block",
+            "entry_title": "Burning Hands",
+            "entry_index": 0,
+            "shape_family": "spell",
+        }
+        candidates = [
+            _candidate("Burning Hands", "Evocation [Fire] spell description body content here." * 3),
+            short_entry,
+        ]
+        accepted, decisions = apply_boundary_filters("SpellsA-B", "SpellsA-B.rtf", candidates)
+        self.assertEqual(len(accepted), 2)
+        self.assertEqual(decisions[1]["reason_code"], "entry_annotated")
+        self.assertEqual(decisions[1]["action"], "accepted")
 
 
 if __name__ == "__main__":

--- a/tests/test_entry_pipeline_integration.py
+++ b/tests/test_entry_pipeline_integration.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.ingest_srd35.rtf_decoder import decode_rtf_spans
+from scripts.ingest_srd35.extraction_ir import build_extraction_ir
+from scripts.ingest_srd35.entry_annotator import annotate_entries
+from scripts.ingest_srd35.sectioning import split_sections_from_blocks
+from scripts.ingest_srd35.content_types import load_content_types
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "srd_35_entries"
+
+
+def _process_fixture(path: Path) -> list[dict]:
+    """Run a fixture through decode -> IR -> annotate -> section."""
+    rtf = path.read_text(encoding="latin-1")
+    spans = decode_rtf_spans(rtf)
+    ir = build_extraction_ir(file_name=path.name, spans=spans)
+    config_text = (REPO_ROOT / "configs" / "content_types.yaml").read_text(encoding="utf-8")
+    types = load_content_types(config_text)
+    annotate_entries(ir["blocks"], file_name=path.name, content_types=types)
+    return split_sections_from_blocks(path.stem, ir["blocks"])
+
+
+class SpellsExcerptIntegrationTests(unittest.TestCase):
+    def test_two_spells_become_two_entry_sections(self) -> None:
+        sections = _process_fixture(FIXTURE_DIR / "SpellsExcerpt.rtf")
+        entry_sections = [s for s in sections if "entry_metadata" in s]
+        self.assertEqual(len(entry_sections), 2)
+        titles = {s["entry_metadata"]["entry_title"] for s in entry_sections}
+        self.assertEqual(titles, {"Sanctuary", "Scare"})
+        for s in entry_sections:
+            meta = s["entry_metadata"]
+            self.assertEqual(meta["entry_category"], "Spells")
+            self.assertEqual(meta["entry_chunk_type"], "spell_entry")
+
+
+class FeatsExcerptIntegrationTests(unittest.TestCase):
+    def test_two_feats_become_two_entry_sections(self) -> None:
+        sections = _process_fixture(FIXTURE_DIR / "FeatsExcerpt.rtf")
+        entry_sections = [s for s in sections if "entry_metadata" in s]
+        self.assertEqual(len(entry_sections), 2)
+        titles = [s["entry_metadata"]["entry_title"] for s in entry_sections]
+        self.assertIn("ACROBATIC", titles)
+        self.assertIn("POWER ATTACK", titles)
+
+
+class ConditionsExcerptIntegrationTests(unittest.TestCase):
+    def test_four_conditions_become_four_entry_sections(self) -> None:
+        sections = _process_fixture(FIXTURE_DIR / "ConditionsExcerpt.rtf")
+        entry_sections = [s for s in sections if "entry_metadata" in s]
+        self.assertEqual(len(entry_sections), 4)
+        titles = [s["entry_metadata"]["entry_title"] for s in entry_sections]
+        self.assertEqual(titles, ["Blinded", "Confused", "Dazed", "Frightened"])
+        for s in entry_sections:
+            self.assertEqual(s["entry_metadata"]["entry_chunk_type"], "condition_entry")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_entry_pipeline_integration.py
+++ b/tests/test_entry_pipeline_integration.py
@@ -7,7 +7,9 @@ from scripts.ingest_srd35.rtf_decoder import decode_rtf_spans
 from scripts.ingest_srd35.extraction_ir import build_extraction_ir
 from scripts.ingest_srd35.entry_annotator import annotate_entries
 from scripts.ingest_srd35.sectioning import split_sections_from_blocks
+from scripts.ingest_srd35.boundary_filter import apply_boundary_filters
 from scripts.ingest_srd35.content_types import load_content_types
+from scripts.ingest_srd35.pipeline import _compute_processing_hints
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -25,6 +27,16 @@ def _process_fixture(path: Path) -> list[dict]:
     return split_sections_from_blocks(path.stem, ir["blocks"])
 
 
+def _process_fixture_full(path: Path) -> list[dict]:
+    """Run a fixture all the way through boundary filter (covers the
+    forward_merge_bucket interaction with entry sections)."""
+    sections = _process_fixture(path)
+    accepted, _decisions = apply_boundary_filters(
+        path.stem, path.name, sections, boilerplate_phrases=set(),
+    )
+    return accepted
+
+
 class SpellsExcerptIntegrationTests(unittest.TestCase):
     def test_two_spells_become_two_entry_sections(self) -> None:
         sections = _process_fixture(FIXTURE_DIR / "SpellsExcerpt.rtf")
@@ -39,6 +51,18 @@ class SpellsExcerptIntegrationTests(unittest.TestCase):
 
 
 class FeatsExcerptIntegrationTests(unittest.TestCase):
+    """Synthetic split-block fixture: ACROBATIC and [GENERAL] are on separate
+    \\par lines so the title/subtitle predicate fires.
+
+    NOTE: real Feats.rtf encodes the title and [TAG] subtitle in the SAME
+    \\par (e.g., `\\par ACROBATIC }{\\fs20 [GENERAL]\\par`), which the
+    current entry_with_statblock shape does NOT detect — only ~1/150 real
+    feats annotate. This synthetic fixture intentionally splits them so
+    pipeline integration is testable, but it does NOT prove that real-corpus
+    feat detection works yet. Tracked as a known gap; fix path is either
+    splitting blocks at intra-paragraph font-size changes in the IR builder
+    or extending the shape rule to accept inline subtitle changes.
+    """
     def test_two_feats_become_two_entry_sections(self) -> None:
         sections = _process_fixture(FIXTURE_DIR / "FeatsExcerpt.rtf")
         entry_sections = [s for s in sections if "entry_metadata" in s]
@@ -57,6 +81,43 @@ class ConditionsExcerptIntegrationTests(unittest.TestCase):
         self.assertEqual(titles, ["Blinded", "Confused", "Dazed", "Frightened"])
         for s in entry_sections:
             self.assertEqual(s["entry_metadata"]["entry_chunk_type"], "condition_entry")
+
+
+class GapBlocksDoNotPolluteEntrySectionTests(unittest.TestCase):
+    """Reviewer-flagged risk: file-opener blocks (e.g., 'SPELLS EXCERPT'
+    title) used to be merged-forward and then prepended into the FIRST
+    entry section by boundary_filter, polluting the entry's content and
+    shifting structure_cuts offsets. Now the bucket is promoted to a
+    standalone non-entry section ahead of the entry."""
+
+    def test_first_entry_content_does_not_contain_file_opener(self) -> None:
+        sections = _process_fixture_full(FIXTURE_DIR / "SpellsExcerpt.rtf")
+        entry_sections = [s for s in sections if "entry_metadata" in s]
+        self.assertGreaterEqual(len(entry_sections), 1)
+        first = entry_sections[0]
+        self.assertEqual(first["entry_metadata"]["entry_title"], "Sanctuary")
+        # The opener "SPELLS EXCERPT" must NOT have been prepended.
+        self.assertNotIn("SPELLS EXCERPT", first["content"])
+        # Sanctuary's own block content is intact.
+        self.assertTrue(first["content"].startswith("Sanctuary"))
+
+    def test_first_entry_processing_hints_offset_lands_after_stat_block(self) -> None:
+        # The block-derived stat_block_end_char (now stamped on
+        # entry_metadata at sectioning time) must point to the end of
+        # the spell's stat block, not somewhere shifted by a prepended
+        # opener or by description text that happens to look like a
+        # field line.
+        sections = _process_fixture_full(FIXTURE_DIR / "SpellsExcerpt.rtf")
+        first = next(s for s in sections if "entry_metadata" in s)
+        meta = first["entry_metadata"]
+        hints = _compute_processing_hints(first, meta)
+        self.assertIn("structure_cuts", hints)
+        cut = hints["structure_cuts"][0]
+        # Slice must include the last stat field ("Components: V, S, DF")
+        # and exclude the description text that follows.
+        sliced = first["content"][:cut["char_offset"]]
+        self.assertIn("Components: V, S, DF", sliced)
+        self.assertNotIn("Any opponent", sliced)
 
 
 if __name__ == "__main__":

--- a/tests/test_ingest_srd_35.py
+++ b/tests/test_ingest_srd_35.py
@@ -124,6 +124,47 @@ class IngestSrd35Tests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             ingest_source(self.manifest, self.repo_root, require_schema_validation=True)
 
+    def test_processing_hints_validates_in_schema(self) -> None:
+        import jsonschema
+
+        repo_root = Path(__file__).resolve().parent.parent
+        schema = json.loads(
+            (repo_root / "schemas" / "canonical_document.schema.json").read_text(encoding="utf-8")
+        )
+        common = json.loads(
+            (repo_root / "schemas" / "common.schema.json").read_text(encoding="utf-8")
+        )
+        resolver = jsonschema.RefResolver.from_schema(
+            schema,
+            store={
+                "common.schema.json": common,
+                "./common.schema.json": common,
+            },
+        )
+        sample_with_hints = {
+            "document_id": "srd_35::spellss::001_sanctuary",
+            "source_ref": {
+                "source_id": "srd_35",
+                "title": "SRD",
+                "edition": "3.5e",
+                "source_type": "srd",
+                "authority_level": "official_reference",
+            },
+            "locator": {
+                "section_path": ["Spells", "Sanctuary"],
+                "source_location": "SpellsS.rtf#001_sanctuary",
+                "entry_title": "Sanctuary",
+            },
+            "content": "Sanctuary\nAbjuration\nLevel: Clr 1\n\nDescription.",
+            "processing_hints": {
+                "chunk_type_hint": "spell_entry",
+                "structure_cuts": [
+                    {"kind": "stat_block_end", "char_offset": 30, "child_chunk_type": "stat_block"}
+                ],
+            },
+        }
+        jsonschema.validate(sample_with_hints, schema, resolver=resolver)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sectioning_two_path.py
+++ b/tests/test_sectioning_two_path.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.ingest_srd35.sectioning import split_sections_from_blocks
+
+
+def _block(text: str, **fields) -> dict:
+    base = {
+        "block_id": f"b{abs(hash(text)) % 10000:04d}",
+        "block_type": "paragraph",
+        "text": text,
+        "font_size": 24,
+        "starts_with_bold": False,
+        "all_bold": False,
+    }
+    base.update(fields)
+    return base
+
+
+def _annotated(block: dict, **annotations) -> dict:
+    block.update(annotations)
+    return block
+
+
+class EntryDrivenSectioningTests(unittest.TestCase):
+    def test_one_entry_one_section(self) -> None:
+        blocks = [
+            _annotated(
+                _block("Sanctuary"),
+                entry_index=0, entry_role="title", entry_type="spell",
+                entry_category="Spells", entry_chunk_type="spell_entry",
+                entry_title="Sanctuary", shape_family="entry_with_statblock",
+            ),
+            _annotated(
+                _block("Abjuration", font_size=20),
+                entry_index=0, entry_role="subtitle", entry_type="spell",
+                entry_category="Spells", entry_chunk_type="spell_entry",
+                entry_title="Sanctuary", shape_family="entry_with_statblock",
+            ),
+            _annotated(
+                _block("Level: Clr 1", font_size=20, starts_with_bold=True),
+                entry_index=0, entry_role="stat_field", entry_type="spell",
+                entry_category="Spells", entry_chunk_type="spell_entry",
+                entry_title="Sanctuary", shape_family="entry_with_statblock",
+            ),
+        ]
+        sections = split_sections_from_blocks("SpellsS", blocks)
+        self.assertEqual(len(sections), 1)
+        s = sections[0]
+        self.assertEqual(s["section_title"], "Sanctuary")
+        self.assertIn("Sanctuary\nAbjuration\nLevel: Clr 1", s["content"])
+        self.assertIn("entry_metadata", s)
+        meta = s["entry_metadata"]
+        self.assertEqual(meta["entry_type"], "spell")
+        self.assertEqual(meta["entry_category"], "Spells")
+        self.assertEqual(meta["entry_chunk_type"], "spell_entry")
+        self.assertEqual(meta["entry_title"], "Sanctuary")
+        self.assertEqual(meta["entry_index"], 0)
+
+    def test_two_entries_two_sections(self) -> None:
+        blocks = []
+        for idx, title in enumerate(["Sanctuary", "Scare"]):
+            for role, text, size, bold in [
+                ("title", title, 24, False),
+                ("subtitle", "Abjuration", 20, False),
+                ("stat_field", "Level: x", 20, True),
+            ]:
+                blocks.append(_annotated(
+                    _block(text, font_size=size, starts_with_bold=bold),
+                    entry_index=idx, entry_role=role, entry_type="spell",
+                    entry_category="Spells", entry_chunk_type="spell_entry",
+                    entry_title=title, shape_family="entry_with_statblock",
+                ))
+        sections = split_sections_from_blocks("SpellsS", blocks)
+        self.assertEqual(len(sections), 2)
+        self.assertEqual(sections[0]["section_title"], "Sanctuary")
+        self.assertEqual(sections[1]["section_title"], "Scare")
+
+    def test_unannotated_gap_becomes_separate_section(self) -> None:
+        blocks = [
+            _block("OGL boilerplate text here."),
+            _annotated(
+                _block("Sanctuary"),
+                entry_index=0, entry_role="title", entry_type="spell",
+                entry_category="Spells", entry_chunk_type="spell_entry",
+                entry_title="Sanctuary", shape_family="entry_with_statblock",
+            ),
+            _annotated(
+                _block("Abjuration", font_size=20),
+                entry_index=0, entry_role="subtitle", entry_type="spell",
+                entry_category="Spells", entry_chunk_type="spell_entry",
+                entry_title="Sanctuary", shape_family="entry_with_statblock",
+            ),
+            _annotated(
+                _block("Level: Clr 1", font_size=20, starts_with_bold=True),
+                entry_index=0, entry_role="stat_field", entry_type="spell",
+                entry_category="Spells", entry_chunk_type="spell_entry",
+                entry_title="Sanctuary", shape_family="entry_with_statblock",
+            ),
+        ]
+        sections = split_sections_from_blocks("SpellsS", blocks)
+        # Expect 2 sections: preamble (no entry_metadata) + Sanctuary
+        self.assertEqual(len(sections), 2)
+        self.assertNotIn("entry_metadata", sections[0])
+        self.assertIn("entry_metadata", sections[1])
+
+
+class HeadingCandidateFallbackTests(unittest.TestCase):
+    def test_no_annotations_falls_back_to_heading_candidates(self) -> None:
+        # Today's behavior must continue when no entry_index is present.
+        blocks = [
+            {"block_id": "b0001", "block_type": "heading_candidate", "text": "Some Heading", "font_size": 24, "starts_with_bold": False, "all_bold": False},
+            {"block_id": "b0002", "block_type": "paragraph", "text": "Some long body content " * 5, "font_size": 24, "starts_with_bold": False, "all_bold": False},
+        ]
+        sections = split_sections_from_blocks("Test", blocks)
+        # Old logic produces a section titled "Some Heading" with the body content.
+        self.assertGreater(len(sections), 0)
+        self.assertNotIn("entry_metadata", sections[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Part **3 of 4** in the chunker rewrite. **The behavioral change.** Wires PR 2's annotator into the ingestion pipeline; entry-bearing files now produce per-entry canonical docs.

**Stacked on #76 (PR 2). Merge PR 1 → PR 2 → this in order.**

### What this PR does

- **Sectioning two-path** (`split_sections_from_blocks`): when blocks have `entry_index`, group by entry; unannotated gap blocks fall through to today's heading-candidate logic. Same output dict shape; entry-driven sections add optional `entry_metadata`.
- **Boundary filter cleanup**: deleted `_SPELL_BLOCK_FIELDS` (private vocabulary) + `_looks_spell_block_field()`. Entry-annotated sections accepted as-is via guard at top of loop. `BOILERPLATE_PHRASES` constants moved to `configs/bootstrap_sources/srd_35.manifest.json` as a per-source field.
- **Pipeline wiring**: `annotate_entries` runs between `build_extraction_ir` and `split_sections_from_blocks`. Canonical doc emission branches on `entry_metadata`: entry docs get `section_path = [category, title]`, `locator.entry_title`, and `processing_hints` with `chunk_type_hint` + optional `structure_cuts`. Non-entry docs unchanged.
- **Schema**: `canonical_document.schema.json` gains `processing_hints` (additive optional, `additionalProperties: false` preserved per project memory).
- **Synthetic entry fixtures**: `tests/fixtures/srd_35_entries/{Spells,Feats,Conditions}Excerpt.rtf` + integration tests (`test_entry_pipeline_integration.py`).
- **Diagnostics**: `canonical_report.json` gains `entry_annotation_summary` (files_with_entries, passthrough categories, entries_by_type, shape_match_failures).

### Real-corpus smoke evidence

Ran `python scripts/ingest_srd_35.py --force` against the SRD 3.5 corpus:

| Metric | Value |
|---|---|
| Total canonical docs | **3257** (up from ~80 baseline) |
| `files_with_entries` | 11 |
| `files_passthrough_no_eligible_type` | 71 |
| `files_passthrough_no_shape_match` | 4 |
| `entries_by_type.spell` | **236** |
| `entries_by_type.condition` | **76** |
| `entries_by_type.feat` | 1 ⚠️ |

Per-spell sectioning works as designed — sample document IDs: `srd_35::spellsa_b::002_acid_arrow`, `srd_35::spellsa_b::003_acid_fog`, `srd_35::spellsa_b::004_acid_splash`. Each spell becomes its own canonical doc with `section_path: ["Spells", title]` and `locator.entry_title`.

### Honest known gaps (follow-up scope, not blocking)

1. **Feat detection captures only 1/~150 feats.** Real `Feats.rtf` encodes the title and `[TAG]` subtitle as a single paragraph (`\par ACROBATIC }{\fs20 [GENERAL]\par`), but the `entry_with_statblock` shape requires title and subtitle as adjacent blocks. The synthetic `FeatsExcerpt.rtf` had to be split for tests to pass. **Fix path**: extend the annotator to also accept "title-and-subtitle-in-one-block-with-internal-fs-change" as a valid title pattern, OR have the IR builder split blocks at intra-paragraph font-size boundaries. Either is additive and doesn't restructure the architecture.
2. **`EpicSpells.rtf`, `DivineDomainsandSpells.rtf`, `EpicFeats.rtf`, `DivineAbilitiesandFeats.rtf`**: matched their file_match but no shapes fired (recorded in `shape_match_failures`). Likely the same intra-paragraph encoding pattern, plus possibly different field-label conventions.
3. **236 spells out of estimated 600+**: regular `Spells*.rtf` files yield clean detection; the divine/epic variants need investigation per #2.

These are tuning work for the shape rules, not architectural problems. The config-driven design absorbs them additively.

### Spec & plan
- Design: `docs/plans/2026-04-23-chunker-rewrite-formatting-aware-design.md` §4.4
- Plan: `docs/plans/2026-04-23-chunker-rewrite-formatting-aware-implementation.md` PR 3 (Tasks 11–16)

### Test plan
- [x] Existing fixture goldens **byte-identical** for non-entry content (the load-bearing back-compat contract).
- [x] New synthetic entry fixtures produce expected per-entry canonical docs (3 integration tests, all green).
- [x] `canonical_document.schema.json` validates produced docs (with and without `processing_hints`).
- [x] Real corpus produces sensible `entry_annotation_summary` counts.
- [x] Full suite: 216 passed, 1 deselected (pre-existing schema-path env failure), 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)