### PR TITLE
feat(eval): phase 1 gold-set eval harness with tagged failures (closes #24)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -47,3 +47,11 @@ At minimum, a regression pass should check:
 1. Retrieval includes evidence from the expected source and section/entry.
 2. The answer behavior matches `expected_behavior`.
 3. Citation anchors support the claim type implied by `expected_answer_notes`.
+
+## How to Rerun
+
+```
+python scripts/run_phase1_eval.py
+```
+
+Writes `evals/reports/phase1_gold_latest.json` (machine) and `_latest.md` (human). Failing cases first, clean tail collapsed. The harness is a reporter — exits 0 regardless of tag counts. See `docs/plans/2026-04-25-issue-24-gold-eval.md` for the design.

--- a/evals/reports/phase1_gold_latest.json
+++ b/evals/reports/phase1_gold_latest.json
@@ -1,0 +1,976 @@
+{
+  "dataset_id": "phase1_gold_v1",
+  "run_started_at": "2026-04-26T04:02:48Z",
+  "case_count": 30,
+  "tag_counts": {
+    "retrieval_miss": 0,
+    "wrong_section": 9,
+    "wrong_entry": 0,
+    "citation_mismatch": 1,
+    "unsupported_inference": 0,
+    "missing_abstain": 1,
+    "unnecessary_abstain": 15,
+    "edition_boundary_failure": 0,
+    "_clean": 5
+  },
+  "behavior_match_rate": 0.47,
+  "cases": [
+    {
+      "eval_id": "P1-DL-001",
+      "question": "When does a character provoke an attack of opportunity from movement?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "Sometimes a combatant in a melee lets her guard down. In this case, combatants near her can take advantage of her lapse in defense to attack her for free. These free attacks are called attacks of opportunity.\nThreatened Squares: You threaten all squares into which you can make a melee attack, even when it is not your action. Generally, that means everything in all squares adjacent to your space (including diagonally). An enemy that takes certain actions while in a threatened square provokes an a…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::combati::014_attacks_of_opportunity",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "CombatI",
+              "ATTACKS OF OPPORTUNITY"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [
+            "attack",
+            "opportunity"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-DL-002",
+      "question": "What does the total defense action do to Armor Class?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-DL-003",
+      "question": "What is the default speed for a human in combat movement terms?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-DL-004",
+      "question": "Can a character take a 5-foot step if they did any other movement in the same round?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-DL-005",
+      "question": "What does being dazzled do?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-EX-001",
+      "question": "Does drinking a potion provoke an attack of opportunity?",
+      "question_type": "exception_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "A potion is a magic liquid that produces its effect when imbibed. Magic oils are similar to potions, except that oils are applied externally rather than imbibed. A potion or oil can be used only once. It can duplicate the effect of a spell of up to 3rd level that has a casting time of less than 1 minute.\nPotions are like spells cast upon the imbiber. The character taking the potion doesn't get to make any decisions about the effect --the caster who brewed the potion has already done so. The drin…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::magicitemsiii::002_potions_and_oils",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "MagicItemsIII",
+              "POTIONS AND OILS"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [
+            "potion"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-EX-002",
+      "question": "Can you make attacks of opportunity while flat-footed?",
+      "question_type": "exception_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "Benefit: You may make a number of additional attacks of opportunity equal to your Dexterity bonus.\nWith this feat, you may also make attacks of opportunity while flat-footed.\nNormal: A character without this feat can make only one attack of opportunity per round and can't make attacks of opportunity while flat-footed.\nSpecial: The Combat Reflexes feat does not allow a rogue to use her opportunist ability more than once per round.\nA fighter may select Combat Reflexes as one of his fighter bonus f…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::feats::022_combat_reflexes_general",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "Feats",
+              "COMBAT REFLEXES [GENERAL]"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [
+            "attacks",
+            "flat",
+            "footed",
+            "make",
+            "opportunity",
+            "while"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-EX-003",
+      "question": "Does firing a ranged weapon while threatened provoke an attack of opportunity?",
+      "question_type": "exception_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "Prerequisites: Dodge, Mobility, Point Blank Shot.\nBenefit: The character does not incur any attacks of opportunity for firing a bow when threatened.\nNormal: Without this feat, a character incurs an attack of opportunity from all opponents who threaten him or her whenever he or she uses a bow.",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::epicfeats::020_combat_archery_epic",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "EpicFeats",
+              "COMBAT ARCHERY [EPIC]"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [
+            "attack",
+            "firing",
+            "opportunity",
+            "threatened"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-EX-004",
+      "question": "Can you run in heavy armor?",
+      "question_type": "exception_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-EX-005",
+      "question": "Can a helpless target make attacks of opportunity?",
+      "question_type": "exception_lookup",
+      "expected_behavior": "supported_inference",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "A helpless opponent is someone who is bound, sleeping, paralyzed, unconscious, or otherwise at your mercy.\nRegular Attack: A helpless character takes a -4 penalty to AC against melee attacks, but no penalty to AC against ranged attacks.\nA helpless defender can't use any Dexterity bonus to AC. In fact, his Dexterity score is treated as if it were 0 and his Dexterity modifier to AC as if it were -5 (and a rogue can sneak attack him).\nCoup de Grace: As a full-round action, you can use a melee weapo…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::combatii::011_helpless_defenders",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "CombatII",
+              "HELPLESS DEFENDERS"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": true,
+          "edition_match": true,
+          "token_overlap": [
+            "attacks",
+            "helpless"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-NE-001",
+      "question": "What does the Power Attack feat allow you to trade?",
+      "question_type": "named_entry",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-NE-002",
+      "question": "Without the Two-Weapon Fighting feat and with a non-light off-hand weapon, what are the two-weapon attack penalties?",
+      "question_type": "named_entry",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-NE-003",
+      "question": "How does the Dodge feat work?",
+      "question_type": "named_entry",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-NE-004",
+      "question": "What does Magic Missile do on a hit roll?",
+      "question_type": "named_entry",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-NE-005",
+      "question": "What does the Cleave feat trigger on?",
+      "question_type": "named_entry",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-MC-001",
+      "question": "Can you take a 5-foot step and still make a full attack?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [],
+      "actual_summary": {
+        "primary_excerpt": "If you get more than one attack per round because your base attack bonus is high enough, because you fight with two weapons or a double weapon or for some special reason you must use a full-round action to get your additional attacks. You do not need to specify the targets of your attacks ahead of time. You can see how the earlier attacks turn out before assigning the later ones.\nThe only movement you can take during a full attack is a 5-foot step. You may take the step before, after, or between…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::combati::025_full_attack",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "CombatI",
+              "Full Attack"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": true,
+          "entry_match": true,
+          "edition_match": true,
+          "token_overlap": [
+            "5",
+            "attack",
+            "foot",
+            "full",
+            "step",
+            "take"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-MC-002",
+      "question": "If a character is invisible and attacks, what combat advantages apply to that first attack?",
+      "question_type": "multi_chunk",
+      "expected_behavior": "supported_inference",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-MC-003",
+      "question": "Can you cast defensively while threatened, and what check determines success?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-MC-004",
+      "question": "If you use Tumble to move through threatened squares, what does it prevent and what does it not prevent?",
+      "question_type": "multi_chunk",
+      "expected_behavior": "supported_inference",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-MC-005",
+      "question": "Can you charge through difficult terrain?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section",
+        "citation_mismatch"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "Diagonals: When measuring distance, the first diagonal counts as 1 square, the second counts as 2 squares, the third counts as 1, the fourth as 2, and so on.\nYou can't move diagonally past a corner (even by taking a 5-foot step). You can move diagonally past a creature, even an opponent.\nYou can also move diagonally past other impassable obstacles, such as pits.\nClosest Creature: When it's important to determine the closest square or creature to a location, if two squares or creatures are equall…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::combatii::004_measuring_distance",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "CombatII",
+              "Measuring Distance"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [],
+          "citation_mismatch": true
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-TB-001",
+      "question": "What Strength score carrying capacity applies to a medium load for Strength 10?",
+      "question_type": "table_dependent",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-TB-002",
+      "question": "What ability modifier does an ability score of 18 provide?",
+      "question_type": "table_dependent",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "The ability that your powers depend on--your key ability score as a manifester--is related to what psionic class (or classes) you have levels in: Intelligence (psion), Wisdom (psychic warrior), and Charisma (wilder). The modifier for this ability is referred to as your key ability modifier. If your character's key ability score is 9 or lower, you can't manifest powers from that psionic class.\nJust as a high Intelligence score grants bonus spells to a wizard and a high Wisdom score grants bonus s…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::psionicclasses::004_abilities_and_manifesters",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "PsionicClasses",
+              "ABILITIES AND MANIFESTERS"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [
+            "ability",
+            "modifier",
+            "score"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-TB-003",
+      "question": "What is the armor check penalty for full plate?",
+      "question_type": "table_dependent",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "The following specific suits of armor usually are preconstructed with exactly the qualities described here.\nAdamantine Breastplate: This nonmagical breastplate is made of adamantine, giving its wearer damage reduction of 2/-.\nNo aura (nonmagical); Price 10,200 gp.\nBanded Mail of Luck: Ten 100-gp gems adorn this +3 banded mail. Once per week, the armor allows its wearer to require that an attack roll made against him be rerolled. He must take whatever consequences come from the second roll. The w…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::magicitemsii::004_specific_armors",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "MagicItemsII",
+              "Specific Armors"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [
+            "armor"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-TB-004",
+      "question": "What cover bonus does improved cover grant?",
+      "question_type": "direct_lookup",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "abstain",
+      "tags": [
+        "unnecessary_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-TB-005",
+      "question": "What size modifier applies to attack rolls for a Large creature?",
+      "question_type": "table_dependent",
+      "expected_behavior": "direct_answer",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "wrong_section"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "Your attack bonus with a melee weapon is:\nBase attack bonus + Strength modifier + size modifier\nWith a ranged weapon, your attack bonus is:\nBase attack bonus + Dexterity modifier + size modifier + range penalty\nTable: Size Modifiers |\nSize | Size Modifier | Size | Size Modifier |\nColossal | -8 | Small | +1 |\nGargantuan | -4 | Tiny | +2 |\nHuge | -2 | Diminutive | +4 |\nLarge | -1 | Fine | +8 |\nMedium | +0 | | |",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::combati::005_attack_bonus",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "CombatI",
+              "ATTACK BONUS"
+            ],
+            "entry_title": null
+          },
+          {
+            "citation_id": "cit_2",
+            "chunk_id": "chunk::srd_35::equipment::006_weapon_categories",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "Equipment",
+              "WEAPON CATEGORIES"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [
+            "attack",
+            "large",
+            "modifier",
+            "size"
+          ],
+          "citation_mismatch": false
+        },
+        {
+          "citation_id": "cit_2",
+          "source_match": true,
+          "section_match": false,
+          "entry_match": false,
+          "edition_match": true,
+          "token_overlap": [
+            "large",
+            "size"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 2
+      }
+    },
+    {
+      "eval_id": "P1-IE-001",
+      "question": "How does the warlock Eldritch Blast scale by level in D&D 3.5e?",
+      "question_type": "insufficient_evidence",
+      "expected_behavior": "abstain",
+      "actual_answer_type": "abstain",
+      "tags": [],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-IE-002",
+      "question": "What are Artificer infusion slots at level 5?",
+      "question_type": "insufficient_evidence",
+      "expected_behavior": "abstain",
+      "actual_answer_type": "abstain",
+      "tags": [],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-IE-003",
+      "question": "Can I spend inspiration to gain advantage on an attack roll?",
+      "question_type": "insufficient_evidence",
+      "expected_behavior": "abstain",
+      "actual_answer_type": "grounded",
+      "tags": [
+        "missing_abstain"
+      ],
+      "actual_summary": {
+        "primary_excerpt": "You project a field of improbability around yourself, creating a fleeting protective shell. You gain a +4 deflection bonus to Armor Class.\nYou can manifest this power instantly, quickly enough to gain its benefits in an emergency. Manifesting the power is an immediate action, like manifesting a quickened power, and it counts toward the normal limit of one quickened power per round. You can use this power even when it's not your turn; however, you must manifest it prior to an opponent's attack ro…",
+        "primary_support_type": "direct_support",
+        "citations": [
+          {
+            "citation_id": "cit_1",
+            "chunk_id": "chunk::srd_35::psionicpowersg_p::037_power_points_5",
+            "source_id": "srd_35",
+            "edition": "3.5e",
+            "section_path": [
+              "PsionicPowersG-P",
+              "Power Points: 5"
+            ],
+            "entry_title": null
+          }
+        ],
+        "abstention_reason": null
+      },
+      "citation_checks": [
+        {
+          "citation_id": "cit_1",
+          "source_match": false,
+          "section_match": null,
+          "entry_match": null,
+          "edition_match": true,
+          "token_overlap": [
+            "attack",
+            "gain"
+          ],
+          "citation_mismatch": false
+        }
+      ],
+      "diagnostics": {
+        "abstention_code": null,
+        "total_candidates": 10,
+        "selected_chunks": 1
+      }
+    },
+    {
+      "eval_id": "P1-IE-004",
+      "question": "How many cantrips does a 5e wizard know at level 1?",
+      "question_type": "insufficient_evidence",
+      "expected_behavior": "abstain",
+      "actual_answer_type": "abstain",
+      "tags": [],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    },
+    {
+      "eval_id": "P1-IE-005",
+      "question": "What does the Hexblade's Curse feature do?",
+      "question_type": "insufficient_evidence",
+      "expected_behavior": "abstain",
+      "actual_answer_type": "abstain",
+      "tags": [],
+      "actual_summary": {
+        "primary_excerpt": null,
+        "primary_support_type": null,
+        "citations": [],
+        "abstention_reason": "Insufficient evidence: retrieved chunks do not clearly match the query."
+      },
+      "citation_checks": [],
+      "diagnostics": {
+        "abstention_code": "weak_signals",
+        "total_candidates": 10,
+        "selected_chunks": 0
+      }
+    }
+  ]
+}

--- a/evals/reports/phase1_gold_latest.md
+++ b/evals/reports/phase1_gold_latest.md
@@ -1,0 +1,332 @@
+# Phase 1 Gold-Set Eval — phase1_gold_v1
+
+- **Run started:** 2026-04-26T04:02:48Z
+- **Cases:** 30
+- **Behavior match rate:** 0.47
+
+## Tag counts
+
+| tag | count |
+|---|---|
+| `retrieval_miss` | 0 |
+| `wrong_section` | 9 |
+| `wrong_entry` | 0 |
+| `citation_mismatch` | 1 |
+| `unsupported_inference` | 0 |
+| `missing_abstain` | 1 |
+| `unnecessary_abstain` | 15 |
+| `edition_boundary_failure` | 0 |
+| `_clean` | 5 |
+
+## Failing cases
+
+### Tag: `wrong_section`
+
+#### P1-DL-001 — direct_lookup → direct_answer
+
+**Question:** When does a character provoke an attack of opportunity from movement?
+
+**Tags:** `wrong_section`
+
+**Actual:** grounded · primary support: direct_support
+> Sometimes a combatant in a melee lets her guard down. In this case, combatants near her can take advantage of her lapse in defense to attack her for free. These free attacks are called attacks of…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | CombatI > ATTACKS OF OPPORTUNITY | yes | no | no | ['attack', 'opportunity'] |
+
+#### P1-EX-001 — exception_lookup → direct_answer
+
+**Question:** Does drinking a potion provoke an attack of opportunity?
+
+**Tags:** `wrong_section`
+
+**Actual:** grounded · primary support: direct_support
+> A potion is a magic liquid that produces its effect when imbibed. Magic oils are similar to potions, except that oils are applied externally rather than imbibed. A potion or oil can be used only…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | MagicItemsIII > POTIONS AND OILS | yes | no | no | ['potion'] |
+
+#### P1-EX-002 — exception_lookup → direct_answer
+
+**Question:** Can you make attacks of opportunity while flat-footed?
+
+**Tags:** `wrong_section`
+
+**Actual:** grounded · primary support: direct_support
+> Benefit: You may make a number of additional attacks of opportunity equal to your Dexterity bonus. With this feat, you may also make attacks of opportunity while flat-footed. Normal: A character…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | Feats > COMBAT REFLEXES [GENERAL] | yes | no | no | ['attacks', 'flat', 'footed', 'make', 'opportunity', 'while'] |
+
+#### P1-EX-003 — exception_lookup → direct_answer
+
+**Question:** Does firing a ranged weapon while threatened provoke an attack of opportunity?
+
+**Tags:** `wrong_section`
+
+**Actual:** grounded · primary support: direct_support
+> Prerequisites: Dodge, Mobility, Point Blank Shot. Benefit: The character does not incur any attacks of opportunity for firing a bow when threatened. Normal: Without this feat, a character incurs an…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | EpicFeats > COMBAT ARCHERY [EPIC] | yes | no | no | ['attack', 'firing', 'opportunity', 'threatened'] |
+
+#### P1-EX-005 — exception_lookup → supported_inference
+
+**Question:** Can a helpless target make attacks of opportunity?
+
+**Tags:** `wrong_section`
+
+**Actual:** grounded · primary support: direct_support
+> A helpless opponent is someone who is bound, sleeping, paralyzed, unconscious, or otherwise at your mercy. Regular Attack: A helpless character takes a -4 penalty to AC against melee attacks, but no…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | CombatII > HELPLESS DEFENDERS | yes | no | yes | ['attacks', 'helpless'] |
+
+#### P1-MC-005 — direct_lookup → direct_answer
+
+**Question:** Can you charge through difficult terrain?
+
+**Tags:** `wrong_section`, `citation_mismatch`
+
+**Actual:** grounded · primary support: direct_support
+> Diagonals: When measuring distance, the first diagonal counts as 1 square, the second counts as 2 squares, the third counts as 1, the fourth as 2, and so on. You can't move diagonally past a corner…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | CombatII > Measuring Distance | yes | no | no | [] |
+
+#### P1-TB-002 — table_dependent → direct_answer
+
+**Question:** What ability modifier does an ability score of 18 provide?
+
+**Tags:** `wrong_section`
+
+**Actual:** grounded · primary support: direct_support
+> The ability that your powers depend on--your key ability score as a manifester--is related to what psionic class (or classes) you have levels in: Intelligence (psion), Wisdom (psychic warrior), and…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | PsionicClasses > ABILITIES AND MANIFESTERS | yes | no | no | ['ability', 'modifier', 'score'] |
+
+#### P1-TB-003 — table_dependent → direct_answer
+
+**Question:** What is the armor check penalty for full plate?
+
+**Tags:** `wrong_section`
+
+**Actual:** grounded · primary support: direct_support
+> The following specific suits of armor usually are preconstructed with exactly the qualities described here. Adamantine Breastplate: This nonmagical breastplate is made of adamantine, giving its…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | MagicItemsII > Specific Armors | yes | no | no | ['armor'] |
+
+#### P1-TB-005 — table_dependent → direct_answer
+
+**Question:** What size modifier applies to attack rolls for a Large creature?
+
+**Tags:** `wrong_section`
+
+**Actual:** grounded · primary support: direct_support
+> Your attack bonus with a melee weapon is: Base attack bonus + Strength modifier + size modifier With a ranged weapon, your attack bonus is: Base attack bonus + Dexterity modifier + size modifier +…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | CombatI > ATTACK BONUS | yes | no | no | ['attack', 'large', 'modifier', 'size'] |
+| cit_2 | srd_35 · 3.5e | Equipment > WEAPON CATEGORIES | yes | no | no | ['large', 'size'] |
+
+### Tag: `missing_abstain`
+
+#### P1-IE-003 — insufficient_evidence → abstain
+
+**Question:** Can I spend inspiration to gain advantage on an attack roll?
+
+**Tags:** `missing_abstain`
+
+**Actual:** grounded · primary support: direct_support
+> You project a field of improbability around yourself, creating a fleeting protective shell. You gain a +4 deflection bonus to Armor Class. You can manifest this power instantly, quickly enough to…
+
+**Citations:**
+
+| id | source · edition | section_path | source | section | entry | tokens shared |
+|----|-----|-----|---|---|---|---|
+| cit_1 | srd_35 · 3.5e | PsionicPowersG-P > Power Points: 5 | no | n/a | n/a | ['attack', 'gain'] |
+
+### Tag: `unnecessary_abstain`
+
+#### P1-DL-002 — direct_lookup → direct_answer
+
+**Question:** What does the total defense action do to Armor Class?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-DL-003 — direct_lookup → direct_answer
+
+**Question:** What is the default speed for a human in combat movement terms?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-DL-004 — direct_lookup → direct_answer
+
+**Question:** Can a character take a 5-foot step if they did any other movement in the same round?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-DL-005 — direct_lookup → direct_answer
+
+**Question:** What does being dazzled do?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-EX-004 — exception_lookup → direct_answer
+
+**Question:** Can you run in heavy armor?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-NE-001 — named_entry → direct_answer
+
+**Question:** What does the Power Attack feat allow you to trade?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-NE-002 — named_entry → direct_answer
+
+**Question:** Without the Two-Weapon Fighting feat and with a non-light off-hand weapon, what are the two-weapon attack penalties?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-NE-003 — named_entry → direct_answer
+
+**Question:** How does the Dodge feat work?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-NE-004 — named_entry → direct_answer
+
+**Question:** What does Magic Missile do on a hit roll?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-NE-005 — named_entry → direct_answer
+
+**Question:** What does the Cleave feat trigger on?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-MC-002 — multi_chunk → supported_inference
+
+**Question:** If a character is invisible and attacks, what combat advantages apply to that first attack?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-MC-003 — direct_lookup → direct_answer
+
+**Question:** Can you cast defensively while threatened, and what check determines success?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-MC-004 — multi_chunk → supported_inference
+
+**Question:** If you use Tumble to move through threatened squares, what does it prevent and what does it not prevent?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-TB-001 — table_dependent → direct_answer
+
+**Question:** What Strength score carrying capacity applies to a medium load for Strength 10?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+#### P1-TB-004 — direct_lookup → direct_answer
+
+**Question:** What cover bonus does improved cover grant?
+
+**Tags:** `unnecessary_abstain`
+
+**Actual:** abstain · primary support: n/a
+> _abstain: Insufficient evidence: retrieved chunks do not clearly match the query._
+
+
+## Clean tail
+
+_5 clean cases (P1-MC-001, P1-IE-001, P1-IE-002, P1-IE-004, P1-IE-005)_

--- a/scripts/eval/__init__.py
+++ b/scripts/eval/__init__.py
@@ -1,0 +1,26 @@
+"""Phase 1 gold-set evaluation harness."""
+from __future__ import annotations
+
+from .contracts import (
+    ActualSummary,
+    CaseOutcome,
+    CitationCheck,
+    CitationSummary,
+    EvalReport,
+    GoldCase,
+)
+from .loader import load_gold_set
+from .runner import run_case
+from .tagger import tag_case
+
+__all__ = [
+    "ActualSummary",
+    "CaseOutcome",
+    "CitationCheck",
+    "CitationSummary",
+    "EvalReport",
+    "GoldCase",
+    "load_gold_set",
+    "run_case",
+    "tag_case",
+]

--- a/scripts/eval/contracts.py
+++ b/scripts/eval/contracts.py
@@ -1,0 +1,89 @@
+"""Frozen dataclasses for the Phase 1 gold-set eval harness."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+_ExpectedBehavior = Literal[
+    "direct_answer", "supported_inference", "narrow_answer", "abstain"
+]
+
+
+@dataclass(frozen=True)
+class GoldCase:
+    """One case in the Phase 1 gold set."""
+
+    eval_id: str
+    question: str
+    question_type: str
+    expected_source_ids: tuple[str, ...]
+    expected_section_or_entry: tuple[str, ...]
+    expected_behavior: _ExpectedBehavior
+    expected_answer_notes: str
+
+
+@dataclass(frozen=True)
+class CitationSummary:
+    """Compact view of one citation, suitable for the report."""
+
+    citation_id: str
+    chunk_id: str
+    source_id: str
+    edition: str
+    section_path: tuple[str, ...]
+    entry_title: str | None
+
+
+@dataclass(frozen=True)
+class CitationCheck:
+    """Per-citation comparison against the gold case's expectations.
+
+    section_match and entry_match are None when expected_section_or_entry
+    is empty (the matchers have nothing to compare against).
+    """
+
+    citation_id: str
+    source_match: bool
+    section_match: bool | None
+    entry_match: bool | None
+    edition_match: bool
+    token_overlap: tuple[str, ...]
+    citation_mismatch: bool
+
+
+@dataclass(frozen=True)
+class ActualSummary:
+    """Compact view of the actual answer produced for a case."""
+
+    primary_excerpt: str | None
+    primary_support_type: str | None
+    citations: tuple[CitationSummary, ...]
+    abstention_reason: str | None
+
+
+@dataclass(frozen=True)
+class CaseOutcome:
+    """One case's result: tags, summaries, diagnostics."""
+
+    eval_id: str
+    question: str
+    question_type: str
+    expected_behavior: _ExpectedBehavior
+    actual_answer_type: Literal["grounded", "abstain"]
+    tags: tuple[str, ...]
+    actual_summary: ActualSummary
+    citation_checks: tuple[CitationCheck, ...]
+    diagnostics: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class EvalReport:
+    """The full report produced by one run over the gold set."""
+
+    dataset_id: str
+    run_started_at: str
+    case_count: int
+    tag_counts: dict[str, int]
+    behavior_match_rate: float
+    cases: tuple[CaseOutcome, ...]

--- a/scripts/eval/loader.py
+++ b/scripts/eval/loader.py
@@ -1,0 +1,48 @@
+"""Load the Phase 1 gold set YAML into ``GoldCase`` records."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from .contracts import GoldCase
+
+_REQUIRED_FIELDS: tuple[str, ...] = (
+    "eval_id",
+    "question",
+    "question_type",
+    "expected_source_ids",
+    "expected_section_or_entry",
+    "expected_behavior",
+    "expected_answer_notes",
+)
+
+
+def load_gold_set(path: Path) -> tuple[GoldCase, ...]:
+    """Parse a gold-set YAML file into a tuple of ``GoldCase``."""
+    payload = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    cases_raw = payload.get("cases", []) if isinstance(payload, dict) else []
+    cases: list[GoldCase] = []
+    for index, raw in enumerate(cases_raw):
+        if not isinstance(raw, dict):
+            raise ValueError(f"Case at index {index} is not a mapping")
+        for field in _REQUIRED_FIELDS:
+            if field not in raw:
+                eval_id = raw.get("eval_id", f"<index {index}>")
+                raise ValueError(
+                    f"Case {eval_id} is missing required field '{field}'"
+                )
+        cases.append(
+            GoldCase(
+                eval_id=str(raw["eval_id"]),
+                question=str(raw["question"]),
+                question_type=str(raw["question_type"]),
+                expected_source_ids=tuple(raw["expected_source_ids"] or ()),
+                expected_section_or_entry=tuple(
+                    raw["expected_section_or_entry"] or ()
+                ),
+                expected_behavior=raw["expected_behavior"],
+                expected_answer_notes=str(raw["expected_answer_notes"]),
+            )
+        )
+    return tuple(cases)

--- a/scripts/eval/matching.py
+++ b/scripts/eval/matching.py
@@ -1,0 +1,86 @@
+"""Tokenization and section/entry matching helpers for the eval tagger."""
+from __future__ import annotations
+
+import re
+
+# Built-in stopword list — small, project-internal, no NLTK dependency.
+_STOPWORDS: frozenset[str] = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "do", "does", "did", "doing", "have", "has", "had", "having",
+    "of", "in", "on", "at", "to", "for", "with", "by", "from",
+    "and", "or", "but", "not", "no", "if", "then", "else",
+    "i", "you", "he", "she", "it", "we", "they", "this", "that",
+    "what", "when", "where", "who", "why", "how", "which",
+    "can", "could", "would", "should", "may", "might", "must",
+    "shall", "will",
+})
+
+_WORD = re.compile(r"[a-z0-9]+")
+
+
+def tokenize(text: str) -> set[str]:
+    """Lowercase, alphanumeric word tokens with stopwords removed."""
+    return {t for t in _WORD.findall(text.lower()) if t not in _STOPWORDS}
+
+
+def _looks_like_filename(s: str) -> bool:
+    """Heuristic: treat as a filename if it ends in `.rtf` (pre-strip) or
+    contains no whitespace and no colon (e.g. `combati`, `abilitiesandconditions`)."""
+    return s.endswith(".rtf") or ("." in s) or (
+        " " not in s and ":" not in s and len(s) > 0
+    )
+
+
+def extract_expected_head(expected: tuple[str, ...]) -> str | None:
+    """First element after `.rtf` strip + lowercase, with fallback to [1].
+
+    See spec §3.3 for the exact rule. Returns None only when called on ``()``;
+    callers are expected to short-circuit before reaching here.
+    """
+    if not expected:
+        return None
+    head = expected[0].lower()
+    if head.endswith(".rtf"):
+        head = head[: -len(".rtf")]
+    # If still filename-shaped and a second element exists, prefer it.
+    if _looks_like_filename(head) and len(expected) >= 2:
+        return expected[1].lower()
+    return head
+
+
+def extract_expected_tail(expected: tuple[str, ...]) -> str | None:
+    """Last element of the expected list, lowercased."""
+    if not expected:
+        return None
+    return expected[-1].lower()
+
+
+def section_root_matches(
+    citation_section_path: tuple[str, ...], expected_head: str
+) -> bool:
+    """True if any section_path element substring-matches expected_head, or
+    the colon-prefix matches."""
+    expected_prefix = expected_head.split(":", 1)[0].strip()
+    for elem in citation_section_path:
+        elem_lower = elem.lower()
+        if expected_head in elem_lower:
+            return True
+        elem_prefix = elem_lower.split(":", 1)[0].strip()
+        if expected_prefix and elem_prefix == expected_prefix:
+            return True
+    return False
+
+
+def entry_matches(
+    citation_section_path: tuple[str, ...],
+    citation_entry_title: str | None,
+    expected_tail: str,
+) -> bool:
+    """True if expected_tail is a substring of any section_path element or
+    of the citation's entry_title."""
+    for elem in citation_section_path:
+        if expected_tail in elem.lower():
+            return True
+    if citation_entry_title and expected_tail in citation_entry_title.lower():
+        return True
+    return False

--- a/scripts/eval/report.py
+++ b/scripts/eval/report.py
@@ -1,0 +1,229 @@
+"""Build, serialize, and render evaluation reports."""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import textwrap
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from .contracts import CaseOutcome, EvalReport
+
+
+# Keep this in sync with scripts.eval.tagger._TAG_ORDER.
+_TAG_ORDER: tuple[str, ...] = (
+    "retrieval_miss",
+    "wrong_section",
+    "wrong_entry",
+    "citation_mismatch",
+    "unsupported_inference",
+    "missing_abstain",
+    "unnecessary_abstain",
+    "edition_boundary_failure",
+)
+
+
+def build_report(
+    cases: tuple[CaseOutcome, ...],
+    *,
+    dataset_id: str,
+    run_started_at: str | None = None,
+) -> EvalReport:
+    """Aggregate per-case outcomes into the full ``EvalReport``."""
+    tag_counts: dict[str, int] = {tag: 0 for tag in _TAG_ORDER}
+    clean = 0
+    behavior_match = 0
+    for outcome in cases:
+        if not outcome.tags:
+            clean += 1
+        for tag in outcome.tags:
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+        expected_grounded = outcome.expected_behavior != "abstain"
+        actual_grounded = outcome.actual_answer_type == "grounded"
+        if expected_grounded == actual_grounded:
+            behavior_match += 1
+    tag_counts["_clean"] = clean
+
+    behavior_match_rate = round(behavior_match / len(cases), 2) if cases else 0.0
+    return EvalReport(
+        dataset_id=dataset_id,
+        run_started_at=run_started_at or _now_iso(),
+        case_count=len(cases),
+        tag_counts=tag_counts,
+        behavior_match_rate=behavior_match_rate,
+        cases=cases,
+    )
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_json(report: EvalReport, path: Path) -> None:
+    """Serialize ``report`` to JSON at ``path``."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _report_to_dict(report)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _report_to_dict(report: EvalReport) -> dict[str, Any]:
+    return {
+        "dataset_id": report.dataset_id,
+        "run_started_at": report.run_started_at,
+        "case_count": report.case_count,
+        "tag_counts": dict(report.tag_counts),
+        "behavior_match_rate": report.behavior_match_rate,
+        "cases": [_case_to_dict(c) for c in report.cases],
+    }
+
+
+def _case_to_dict(case: CaseOutcome) -> dict[str, Any]:
+    payload = asdict(case)
+    # Tuples round-trip to lists via asdict already; nothing to fix.
+    return payload
+
+
+def format_tag_counts(report: EvalReport) -> str:
+    """Render the tag-count table (plus clean total) for stdout."""
+    lines: list[str] = []
+    lines.append(f"Dataset:       {report.dataset_id}")
+    lines.append(f"Cases:         {report.case_count}")
+    lines.append(f"Behavior match rate: {report.behavior_match_rate:.2f}")
+    lines.append("")
+    lines.append("Tag counts:")
+    width = max(len(tag) for tag in _TAG_ORDER)
+    for tag in _TAG_ORDER:
+        count = report.tag_counts.get(tag, 0)
+        lines.append(f"  {tag.ljust(width)}  {count}")
+    lines.append(f"  {'_clean'.ljust(width)}  {report.tag_counts.get('_clean', 0)}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Markdown
+# ---------------------------------------------------------------------------
+
+
+def write_markdown(report: EvalReport, path: Path) -> None:
+    """Render the human-facing Markdown report at ``path``."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_render_markdown(report), encoding="utf-8")
+
+
+def _render_markdown(report: EvalReport) -> str:
+    parts: list[str] = []
+    parts.append(f"# Phase 1 Gold-Set Eval — {report.dataset_id}")
+    parts.append("")
+    parts.append(f"- **Run started:** {report.run_started_at}")
+    parts.append(f"- **Cases:** {report.case_count}")
+    parts.append(f"- **Behavior match rate:** {report.behavior_match_rate:.2f}")
+    parts.append("")
+    parts.append("## Tag counts")
+    parts.append("")
+    parts.append("| tag | count |")
+    parts.append("|---|---|")
+    for tag in _TAG_ORDER:
+        parts.append(f"| `{tag}` | {report.tag_counts.get(tag, 0)} |")
+    parts.append(f"| `_clean` | {report.tag_counts.get('_clean', 0)} |")
+    parts.append("")
+
+    failing = [c for c in report.cases if c.tags]
+    clean = [c for c in report.cases if not c.tags]
+
+    parts.append("## Failing cases")
+    parts.append("")
+    if not failing:
+        parts.append("_No failing cases._")
+        parts.append("")
+    else:
+        # Group by primary (first) tag in §3.2 order, but each case is shown once.
+        grouped: dict[str, list[CaseOutcome]] = {tag: [] for tag in _TAG_ORDER}
+        for c in failing:
+            primary_tag = c.tags[0]
+            grouped.setdefault(primary_tag, []).append(c)
+        for tag in _TAG_ORDER:
+            cases_for_tag = grouped.get(tag, [])
+            if not cases_for_tag:
+                continue
+            parts.append(f"### Tag: `{tag}`")
+            parts.append("")
+            for case in cases_for_tag:
+                parts.extend(_render_case_block(case))
+                parts.append("")
+
+    parts.append("## Clean tail")
+    parts.append("")
+    if clean:
+        ids = ", ".join(c.eval_id for c in clean)
+        parts.append(f"_{len(clean)} clean cases ({ids})_")
+    else:
+        parts.append("_No clean cases._")
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _render_case_block(case: CaseOutcome) -> list[str]:
+    lines: list[str] = []
+    lines.append(
+        f"#### {case.eval_id} — {case.question_type} → {case.expected_behavior}"
+    )
+    lines.append("")
+    lines.append(f"**Question:** {case.question}")
+    lines.append("")
+    if case.tags:
+        tag_md = ", ".join(f"`{t}`" for t in case.tags)
+        lines.append(f"**Tags:** {tag_md}")
+    else:
+        lines.append("**Tags:** _(clean)_")
+    lines.append("")
+
+    lines.append(
+        f"**Actual:** {case.actual_answer_type} · "
+        f"primary support: {case.actual_summary.primary_support_type or 'n/a'}"
+    )
+    if case.actual_summary.primary_excerpt:
+        excerpt = textwrap.shorten(
+            case.actual_summary.primary_excerpt, width=200, placeholder="…"
+        )
+        lines.append(f"> {excerpt}")
+    elif case.actual_summary.abstention_reason:
+        lines.append(f"> _abstain: {case.actual_summary.abstention_reason}_")
+    lines.append("")
+
+    if case.citation_checks:
+        lines.append("**Citations:**")
+        lines.append("")
+        lines.append(
+            "| id | source · edition | section_path | source | section | entry | tokens shared |"
+        )
+        lines.append("|----|-----|-----|---|---|---|---|")
+        # Map citation_id → CitationSummary for display.
+        summaries = {c.citation_id: c for c in case.actual_summary.citations}
+        for chk in case.citation_checks:
+            summary = summaries.get(chk.citation_id)
+            if summary is not None:
+                source_label = f"{summary.source_id} · {summary.edition}"
+                section_path_display = (
+                    " > ".join(summary.section_path) if summary.section_path else "(none)"
+                )
+            else:
+                source_label = "?"
+                section_path_display = "?"
+            section_cell = _bool_cell(chk.section_match)
+            entry_cell = _bool_cell(chk.entry_match)
+            source_cell = "yes" if chk.source_match else "no"
+            tokens = list(chk.token_overlap) if chk.token_overlap else []
+            lines.append(
+                f"| {chk.citation_id} | {source_label} | {section_path_display} | "
+                f"{source_cell} | {section_cell} | {entry_cell} | {tokens} |"
+            )
+    return lines
+
+
+def _bool_cell(flag: bool | None) -> str:
+    if flag is None:
+        return "n/a"
+    return "yes" if flag else "no"

--- a/scripts/eval/runner.py
+++ b/scripts/eval/runner.py
@@ -1,0 +1,86 @@
+"""Run a single gold case through the answer pipeline and tag the outcome."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from scripts.answer.contracts import Abstention, GroundedAnswer
+from scripts.answer.pipeline import build_answer
+from scripts.retrieval.evidence_pack import retrieve_evidence
+
+from .contracts import (
+    ActualSummary,
+    CaseOutcome,
+    CitationSummary,
+    GoldCase,
+)
+from .tagger import tag_case
+
+
+def run_case(
+    case: GoldCase,
+    *,
+    db_path: Path,
+    top_k: int,
+) -> CaseOutcome:
+    """Retrieve, build an answer, tag it, and assemble a CaseOutcome."""
+    pack = retrieve_evidence(case.question, db_path=db_path, top_k=top_k)
+    result = build_answer(pack)
+    tags, checks = tag_case(case, result, pack)
+
+    if isinstance(result, GroundedAnswer):
+        actual_answer_type = "grounded"
+        primary = result.segments[0] if result.segments else None
+        primary_excerpt = primary.text if primary is not None else None
+        primary_support_type = primary.support_type if primary is not None else None
+        citations = tuple(
+            CitationSummary(
+                citation_id=c.citation_id,
+                chunk_id=c.chunk_id,
+                source_id=str(c.source_ref.get("source_id", "")),
+                edition=str(c.source_ref.get("edition", "")),
+                section_path=tuple(c.locator.get("section_path", []) or []),
+                entry_title=c.locator.get("entry_title"),
+            )
+            for c in result.citations
+        )
+        actual_summary = ActualSummary(
+            primary_excerpt=primary_excerpt,
+            primary_support_type=primary_support_type,
+            citations=citations,
+            abstention_reason=None,
+        )
+        abstention_code: str | None = None
+    else:
+        abstention: Abstention = result  # type: ignore[assignment]
+        actual_answer_type = "abstain"
+        actual_summary = ActualSummary(
+            primary_excerpt=None,
+            primary_support_type=None,
+            citations=(),
+            abstention_reason=abstention.reason,
+        )
+        abstention_code = abstention.trigger_code
+
+    selected_chunks = (
+        len({c.chunk_id for c in result.citations})
+        if isinstance(result, GroundedAnswer)
+        else 0
+    )
+    diagnostics: dict[str, Any] = {
+        "abstention_code": abstention_code,
+        "total_candidates": pack.trace.total_candidates,
+        "selected_chunks": selected_chunks,
+    }
+
+    return CaseOutcome(
+        eval_id=case.eval_id,
+        question=case.question,
+        question_type=case.question_type,
+        expected_behavior=case.expected_behavior,
+        actual_answer_type=actual_answer_type,
+        tags=tags,
+        actual_summary=actual_summary,
+        citation_checks=checks,
+        diagnostics=diagnostics,
+    )

--- a/scripts/eval/tagger.py
+++ b/scripts/eval/tagger.py
@@ -1,0 +1,158 @@
+"""Failure-tag classifier for one (case, result, pack) triple."""
+from __future__ import annotations
+
+from scripts.answer.contracts import AnswerResult, GroundedAnswer
+from scripts.retrieval.evidence_pack import EvidencePack
+
+from .contracts import CitationCheck, GoldCase
+from .matching import (
+    entry_matches,
+    extract_expected_head,
+    extract_expected_tail,
+    section_root_matches,
+    tokenize,
+)
+
+
+# Tag order matches spec §3.2. Reports group failing cases in this order.
+_TAG_ORDER: tuple[str, ...] = (
+    "retrieval_miss",
+    "wrong_section",
+    "wrong_entry",
+    "citation_mismatch",
+    "unsupported_inference",
+    "missing_abstain",
+    "unnecessary_abstain",
+    "edition_boundary_failure",
+)
+
+
+def tag_case(
+    case: GoldCase,
+    result: AnswerResult,
+    pack: EvidencePack,  # noqa: ARG001 — kept for parity with spec signature
+) -> tuple[tuple[str, ...], tuple[CitationCheck, ...]]:
+    """Compute the failure-tag tuple and per-citation checks for one case."""
+    tags: set[str] = set()
+    checks: list[CitationCheck] = []
+
+    is_grounded = isinstance(result, GroundedAnswer)
+    is_abstain_expected = case.expected_behavior == "abstain"
+
+    # Behavior-class mismatches.
+    if not is_grounded and not is_abstain_expected:
+        tags.add("unnecessary_abstain")
+    if is_grounded and is_abstain_expected:
+        tags.add("missing_abstain")
+
+    if not is_grounded:
+        # No citations to check; return early with empty checks.
+        return _ordered_tags(tags), ()
+
+    grounded: GroundedAnswer = result  # type: ignore[assignment]
+    citations = grounded.citations
+    expected_sources = set(case.expected_source_ids)
+    has_section_expectation = bool(case.expected_section_or_entry)
+    expected_head = (
+        extract_expected_head(case.expected_section_or_entry)
+        if has_section_expectation
+        else None
+    )
+    expected_tail = (
+        extract_expected_tail(case.expected_section_or_entry)
+        if has_section_expectation
+        else None
+    )
+    question_tokens = tokenize(case.question)
+
+    any_source_match = False
+    any_section_match = False
+    any_entry_match = False
+    any_citation_mismatch = False
+    any_edition_failure = False
+
+    for citation in citations:
+        source_id = citation.source_ref.get("source_id", "")
+        edition = citation.source_ref.get("edition", "")
+        section_path = tuple(citation.locator.get("section_path", []) or [])
+        entry_title = citation.locator.get("entry_title")
+        excerpt_tokens = tokenize(citation.excerpt or "")
+        shared = tuple(sorted(question_tokens & excerpt_tokens))
+
+        source_match = bool(expected_sources) and source_id in expected_sources
+        edition_match = edition == "3.5e"
+        if not edition_match:
+            any_edition_failure = True
+
+        if has_section_expectation and expected_head is not None:
+            sec_match: bool | None = section_root_matches(section_path, expected_head)
+        else:
+            sec_match = None
+        if has_section_expectation and expected_tail is not None:
+            ent_match: bool | None = entry_matches(
+                section_path, entry_title, expected_tail
+            )
+        else:
+            ent_match = None
+
+        cm = len(shared) == 0
+        if cm:
+            any_citation_mismatch = True
+
+        if source_match:
+            any_source_match = True
+        if sec_match:
+            any_section_match = True
+        if ent_match:
+            any_entry_match = True
+
+        checks.append(
+            CitationCheck(
+                citation_id=citation.citation_id,
+                source_match=source_match,
+                section_match=sec_match,
+                entry_match=ent_match,
+                edition_match=edition_match,
+                token_overlap=shared,
+                citation_mismatch=cm,
+            )
+        )
+
+    # retrieval_miss only fires when expected_source_ids is non-empty
+    # (abstain-expected cases carry an empty list and never trigger this).
+    if (
+        expected_sources
+        and citations
+        and not any_source_match
+    ):
+        tags.add("retrieval_miss")
+
+    if has_section_expectation and citations:
+        # wrong_section / wrong_entry are mutually exclusive: when sections
+        # are wrong we report only the more specific tag (spec §3.3).
+        if not any_section_match:
+            tags.add("wrong_section")
+        elif not any_entry_match:
+            tags.add("wrong_entry")
+
+    if any_citation_mismatch:
+        tags.add("citation_mismatch")
+
+    if any_edition_failure:
+        tags.add("edition_boundary_failure")
+
+    # unsupported_inference fires only when the gold expects a direct answer
+    # but the primary segment is a supported_inference.
+    if (
+        case.expected_behavior == "direct_answer"
+        and grounded.segments
+        and grounded.segments[0].support_type == "supported_inference"
+    ):
+        tags.add("unsupported_inference")
+
+    return _ordered_tags(tags), tuple(checks)
+
+
+def _ordered_tags(tags: set[str]) -> tuple[str, ...]:
+    """Return tags in canonical §3.2 order."""
+    return tuple(t for t in _TAG_ORDER if t in tags)

--- a/scripts/run_phase1_eval.py
+++ b/scripts/run_phase1_eval.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Run the Phase 1 gold-set eval and write JSON + Markdown reports.
+
+Usage:
+    python scripts/run_phase1_eval.py
+    python scripts/run_phase1_eval.py --top-k 10
+    python scripts/run_phase1_eval.py --eval-set evals/phase1_gold.yaml
+    python scripts/run_phase1_eval.py --output-dir evals/reports
+    python scripts/run_phase1_eval.py --skip-md
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.eval.loader import load_gold_set
+from scripts.eval.report import build_report, format_tag_counts, write_json, write_markdown
+from scripts.eval.runner import run_case
+
+
+_DEFAULT_DB = REPO_ROOT / "data" / "index" / "srd_35" / "lexical.db"
+_DEFAULT_EVAL_SET = REPO_ROOT / "evals" / "phase1_gold.yaml"
+_DEFAULT_OUTPUT_DIR = REPO_ROOT / "evals" / "reports"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the Phase 1 gold-set eval and emit JSON + Markdown reports."
+    )
+    parser.add_argument(
+        "--top-k", type=int, default=10, help="Top-k candidates per query (default: 10)"
+    )
+    parser.add_argument(
+        "--eval-set",
+        type=Path,
+        default=_DEFAULT_EVAL_SET,
+        help=f"Path to gold-set YAML (default: {_DEFAULT_EVAL_SET.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=_DEFAULT_OUTPUT_DIR,
+        help=f"Output directory (default: {_DEFAULT_OUTPUT_DIR.relative_to(REPO_ROOT)})",
+    )
+    parser.add_argument(
+        "--skip-md",
+        action="store_true",
+        help="Skip writing the Markdown report (JSON only).",
+    )
+    parser.add_argument(
+        "--db", type=str, default=None, help="Path to lexical.db (default: auto)"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+
+    db_path = Path(args.db) if args.db else _DEFAULT_DB
+    if not db_path.exists():
+        print(
+            f"Error: lexical.db not found at {db_path}\n"
+            "Build the lexical index first (chunks → index).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    eval_set_path = args.eval_set
+    if not eval_set_path.exists():
+        print(f"Error: eval set not found at {eval_set_path}", file=sys.stderr)
+        sys.exit(1)
+
+    cases = load_gold_set(eval_set_path)
+    run_started_at = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    outcomes = tuple(
+        run_case(case, db_path=db_path, top_k=args.top_k) for case in cases
+    )
+
+    # Pull dataset_id from the YAML header (falls back to the file stem).
+    import yaml as _yaml
+    payload = _yaml.safe_load(eval_set_path.read_text(encoding="utf-8"))
+    dataset_id = (
+        str(payload.get("dataset_id"))
+        if isinstance(payload, dict) and payload.get("dataset_id")
+        else eval_set_path.stem
+    )
+
+    report = build_report(
+        outcomes, dataset_id=dataset_id, run_started_at=run_started_at
+    )
+
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "phase1_gold_latest.json"
+    write_json(report, json_path)
+    if not args.skip_md:
+        md_path = output_dir / "phase1_gold_latest.md"
+        write_markdown(report, md_path)
+
+    print(format_tag_counts(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_answer_citation_binder.py
+++ b/tests/test_answer_citation_binder.py
@@ -61,6 +61,13 @@ def _make_item(
         locator=locator or {"section_path": ["Combat"], "source_location": "test"},
         match_signals=_empty_signals(),
         section_root="Combat",
+        chunk_ids=(chunk_id,),
+        start_chunk_id=chunk_id,
+        end_chunk_id=chunk_id,
+        merge_reason="singleton",
+        parent_chunk_id=None,
+        previous_chunk_id=None,
+        next_chunk_id=None,
     )
 
 

--- a/tests/test_answer_composer.py
+++ b/tests/test_answer_composer.py
@@ -65,6 +65,13 @@ def _make_item(
         locator={"section_path": [section_root], "source_location": "test"},
         match_signals=signals or _make_signals(exact=["q"]),
         section_root=section_root,
+        chunk_ids=(chunk_id,),
+        start_chunk_id=chunk_id,
+        end_chunk_id=chunk_id,
+        merge_reason="singleton",
+        parent_chunk_id=None,
+        previous_chunk_id=None,
+        next_chunk_id=None,
     )
 
 

--- a/tests/test_answer_pipeline.py
+++ b/tests/test_answer_pipeline.py
@@ -81,6 +81,13 @@ def _make_item(
         locator={"section_path": [section_root, "X"], "source_location": "t"},
         match_signals=signals or _make_signals(exact=["q"]),
         section_root=section_root,
+        chunk_ids=(chunk_id,),
+        start_chunk_id=chunk_id,
+        end_chunk_id=chunk_id,
+        merge_reason="singleton",
+        parent_chunk_id=None,
+        previous_chunk_id=None,
+        next_chunk_id=None,
     )
 
 
@@ -94,6 +101,7 @@ def _make_pack(
             document_id=item.document_id,
             section_root=item.section_root,
             candidate_count=1,
+            span_count=1,
         )
         for item in items
     )

--- a/tests/test_answer_support_assessor.py
+++ b/tests/test_answer_support_assessor.py
@@ -57,6 +57,13 @@ def _make_item(signals: MatchSignals, *, chunk_id: str = "chunk::001") -> Eviden
         locator={"section_path": ["Combat"], "source_location": "test"},
         match_signals=signals,
         section_root="Combat",
+        chunk_ids=(chunk_id,),
+        start_chunk_id=chunk_id,
+        end_chunk_id=chunk_id,
+        merge_reason="singleton",
+        parent_chunk_id=None,
+        previous_chunk_id=None,
+        next_chunk_id=None,
     )
 
 

--- a/tests/test_eval_loader.py
+++ b/tests/test_eval_loader.py
@@ -1,0 +1,57 @@
+"""Tests for ``scripts.eval.loader``."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.eval.loader import load_gold_set
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_GOLD_SET_PATH = _REPO_ROOT / "evals" / "phase1_gold.yaml"
+
+
+def test_loads_phase1_gold_set_with_thirty_cases():
+    cases = load_gold_set(_GOLD_SET_PATH)
+    assert len(cases) == 30
+    for case in cases:
+        assert case.eval_id
+        assert case.question
+        assert case.question_type
+        assert case.expected_behavior
+        # expected_source_ids and expected_section_or_entry are tuples (possibly empty).
+        assert isinstance(case.expected_source_ids, tuple)
+        assert isinstance(case.expected_section_or_entry, tuple)
+
+
+def test_abstain_cases_carry_empty_expected_lists():
+    cases = load_gold_set(_GOLD_SET_PATH)
+    abstain_cases = [c for c in cases if c.expected_behavior == "abstain"]
+    assert abstain_cases  # sanity
+    for case in abstain_cases:
+        assert case.expected_source_ids == ()
+        assert case.expected_section_or_entry == ()
+
+
+def test_missing_required_field_raises_value_error(tmp_path):
+    payload = {
+        "dataset_id": "test",
+        "cases": [
+            {
+                "eval_id": "X-001",
+                "question": "What is X?",
+                "question_type": "direct_lookup",
+                "expected_source_ids": ["srd_35"],
+                # missing expected_section_or_entry
+                "expected_behavior": "direct_answer",
+                "expected_answer_notes": "n/a",
+            }
+        ],
+    }
+    p = tmp_path / "broken.yaml"
+    p.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    with pytest.raises(ValueError) as exc_info:
+        load_gold_set(p)
+    assert "expected_section_or_entry" in str(exc_info.value)

--- a/tests/test_eval_matching.py
+++ b/tests/test_eval_matching.py
@@ -1,0 +1,124 @@
+"""Tests for ``scripts.eval.matching``."""
+from __future__ import annotations
+
+from scripts.eval.matching import (
+    entry_matches,
+    extract_expected_head,
+    extract_expected_tail,
+    section_root_matches,
+    tokenize,
+)
+
+
+# ---------------------------------------------------------------------------
+# tokenize
+# ---------------------------------------------------------------------------
+
+
+def test_tokenize_lowercases_and_drops_stopwords():
+    tokens = tokenize("What does the Magic Missile spell DO?")
+    assert "magic" in tokens
+    assert "missile" in tokens
+    assert "spell" in tokens
+    # stopwords removed
+    for sw in ("what", "does", "the", "do"):
+        assert sw not in tokens
+
+
+def test_tokenize_keeps_alphanumerics_and_drops_punctuation():
+    tokens = tokenize("DC 15 + spell-level rules!")
+    assert "dc" in tokens
+    assert "15" in tokens
+    assert "spell" in tokens
+    assert "level" in tokens
+    assert "rules" in tokens
+    # No punctuation tokens.
+    assert all(t.isalnum() for t in tokens)
+
+
+# ---------------------------------------------------------------------------
+# extract_expected_head / extract_expected_tail
+# ---------------------------------------------------------------------------
+
+
+def test_extract_expected_head_drops_rtf_extension():
+    # CombatI.rtf is filename-shaped → falls back to [1].
+    head = extract_expected_head(("CombatI.rtf", "Run"))
+    assert head == "run"
+
+
+def test_extract_expected_head_falls_back_when_first_is_filename():
+    head = extract_expected_head(("Races.rtf", "Races", "Humans"))
+    assert head == "races"
+
+
+def test_extract_expected_head_returns_first_when_only_one_element():
+    # Only one element, even if filename-shaped: use as-is (substring match
+    # in the matcher is generous enough).
+    head = extract_expected_head(("CombatI.rtf",))
+    assert head == "combati"
+
+
+def test_extract_expected_head_returns_lowercased_section_root():
+    head = extract_expected_head(("Combat: Attacks of Opportunity", "Movement"))
+    assert head == "combat: attacks of opportunity"
+
+
+def test_extract_expected_head_empty_returns_none():
+    assert extract_expected_head(()) is None
+
+
+def test_extract_expected_tail_returns_last_lowercased():
+    tail = extract_expected_tail(("Combat: Movement", "5-Foot Step"))
+    assert tail == "5-foot step"
+
+
+def test_extract_expected_tail_empty_returns_none():
+    assert extract_expected_tail(()) is None
+
+
+# ---------------------------------------------------------------------------
+# section_root_matches
+# ---------------------------------------------------------------------------
+
+
+def test_section_root_matches_substring():
+    assert section_root_matches(("Combat", "Attack of Opportunity"), "combat")
+
+
+def test_section_root_matches_colon_prefix():
+    # Citation is "Combat: Attacks of Opportunity"; expected head is "combat".
+    assert section_root_matches(
+        ("Combat: Attacks of Opportunity",), "combat"
+    )
+
+
+def test_section_root_matches_negative():
+    assert not section_root_matches(("Spells", "Magic Missile"), "combat")
+
+
+# ---------------------------------------------------------------------------
+# entry_matches
+# ---------------------------------------------------------------------------
+
+
+def test_entry_matches_against_section_path():
+    assert entry_matches(
+        ("Combat", "Attack of Opportunity", "Movement"),
+        None,
+        "movement",
+    )
+
+
+def test_entry_matches_against_entry_title():
+    assert entry_matches(
+        ("Combat", "Attack of Opportunity"),
+        "Threatened Squares",
+        "threatened",
+    )
+
+
+def test_entry_matches_negative():
+    assert not entry_matches(
+        ("Spells", "Magic Missile"), "Damage", "movement"
+    )

--- a/tests/test_eval_report.py
+++ b/tests/test_eval_report.py
@@ -1,0 +1,166 @@
+"""Tests for ``scripts.eval.report``."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.eval.contracts import (
+    ActualSummary,
+    CaseOutcome,
+    CitationCheck,
+    CitationSummary,
+)
+from scripts.eval.report import build_report, write_json, write_markdown
+
+
+def _make_outcome(
+    *,
+    eval_id: str,
+    expected_behavior: str,
+    actual_answer_type: str,
+    tags: tuple[str, ...] = (),
+    citations: tuple[CitationSummary, ...] = (),
+    citation_checks: tuple[CitationCheck, ...] = (),
+    primary_support_type: str | None = "direct_support",
+) -> CaseOutcome:
+    return CaseOutcome(
+        eval_id=eval_id,
+        question=f"q for {eval_id}",
+        question_type="direct_lookup",
+        expected_behavior=expected_behavior,  # type: ignore[arg-type]
+        actual_answer_type=actual_answer_type,  # type: ignore[arg-type]
+        tags=tags,
+        actual_summary=ActualSummary(
+            primary_excerpt="primary text" if actual_answer_type == "grounded" else None,
+            primary_support_type=primary_support_type if actual_answer_type == "grounded" else None,
+            citations=citations,
+            abstention_reason=None if actual_answer_type == "grounded" else "no evidence",
+        ),
+        citation_checks=citation_checks,
+        diagnostics={
+            "abstention_code": None if actual_answer_type == "grounded" else "empty_evidence",
+            "total_candidates": 0,
+            "selected_chunks": len(citations),
+        },
+    )
+
+
+def _make_summary(citation_id: str = "cit_1") -> CitationSummary:
+    return CitationSummary(
+        citation_id=citation_id,
+        chunk_id=f"chunk::{citation_id}",
+        source_id="srd_35",
+        edition="3.5e",
+        section_path=("Combat", "Attack of Opportunity"),
+        entry_title=None,
+    )
+
+
+def _make_check(
+    citation_id: str = "cit_1",
+    *,
+    section_match: bool | None = True,
+    entry_match: bool | None = True,
+    citation_mismatch: bool = False,
+) -> CitationCheck:
+    return CitationCheck(
+        citation_id=citation_id,
+        source_match=True,
+        section_match=section_match,
+        entry_match=entry_match,
+        edition_match=True,
+        token_overlap=("attack", "opportunity"),
+        citation_mismatch=citation_mismatch,
+    )
+
+
+def test_build_report_counts_tags_and_clean_cases():
+    outcomes = (
+        _make_outcome(eval_id="P1-A", expected_behavior="direct_answer",
+                      actual_answer_type="grounded", tags=()),
+        _make_outcome(eval_id="P1-B", expected_behavior="direct_answer",
+                      actual_answer_type="grounded",
+                      tags=("retrieval_miss", "citation_mismatch")),
+        _make_outcome(eval_id="P1-C", expected_behavior="abstain",
+                      actual_answer_type="abstain", tags=()),
+        _make_outcome(eval_id="P1-D", expected_behavior="direct_answer",
+                      actual_answer_type="abstain", tags=("unnecessary_abstain",)),
+    )
+    report = build_report(outcomes, dataset_id="test_v1", run_started_at="2026-04-25T00:00:00Z")
+
+    assert report.case_count == 4
+    assert report.tag_counts["retrieval_miss"] == 1
+    assert report.tag_counts["citation_mismatch"] == 1
+    assert report.tag_counts["unnecessary_abstain"] == 1
+    assert report.tag_counts["_clean"] == 2
+    # 3 cases match expected behavior class (P1-A grounded, P1-B grounded,
+    # P1-C abstain); P1-D is the only behavior mismatch → 3/4 = 0.75.
+    assert report.behavior_match_rate == 0.75
+
+
+def test_write_json_round_trips(tmp_path: Path):
+    outcomes = (
+        _make_outcome(
+            eval_id="P1-X",
+            expected_behavior="direct_answer",
+            actual_answer_type="grounded",
+            tags=(),
+            citations=(_make_summary(),),
+            citation_checks=(_make_check(),),
+        ),
+    )
+    report = build_report(outcomes, dataset_id="ds", run_started_at="2026-04-25T00:00:00Z")
+    out = tmp_path / "out.json"
+    write_json(report, out)
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["dataset_id"] == "ds"
+    assert payload["case_count"] == 1
+    assert payload["tag_counts"]["_clean"] == 1
+    assert payload["cases"][0]["eval_id"] == "P1-X"
+    assert payload["cases"][0]["citation_checks"][0]["citation_id"] == "cit_1"
+
+
+def test_write_markdown_includes_header_table_failing_block(tmp_path: Path):
+    outcomes = (
+        _make_outcome(
+            eval_id="P1-FAIL",
+            expected_behavior="direct_answer",
+            actual_answer_type="grounded",
+            tags=("retrieval_miss",),
+            citations=(_make_summary(),),
+            citation_checks=(_make_check(section_match=False, entry_match=False),),
+        ),
+        _make_outcome(eval_id="P1-OK", expected_behavior="direct_answer",
+                      actual_answer_type="grounded", tags=()),
+    )
+    report = build_report(outcomes, dataset_id="ds", run_started_at="2026-04-25T00:00:00Z")
+    out = tmp_path / "out.md"
+    write_markdown(report, out)
+    text = out.read_text(encoding="utf-8")
+    assert "Phase 1 Gold-Set Eval" in text
+    assert "Tag counts" in text
+    assert "retrieval_miss" in text
+    assert "P1-FAIL" in text
+    # Clean tail collapsed to one summary line.
+    assert "1 clean cases" in text
+    assert "P1-OK" in text
+
+
+def test_write_markdown_renders_n_a_when_section_match_is_none(tmp_path: Path):
+    outcomes = (
+        _make_outcome(
+            eval_id="P1-AB",
+            expected_behavior="abstain",
+            actual_answer_type="grounded",
+            tags=("missing_abstain",),
+            citations=(_make_summary(),),
+            citation_checks=(
+                _make_check(section_match=None, entry_match=None),
+            ),
+        ),
+    )
+    report = build_report(outcomes, dataset_id="ds", run_started_at="2026-04-25T00:00:00Z")
+    out = tmp_path / "out.md"
+    write_markdown(report, out)
+    text = out.read_text(encoding="utf-8")
+    assert "n/a" in text

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -1,0 +1,102 @@
+"""End-to-end smoke test for ``scripts.eval.runner.run_case``."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.eval.contracts import GoldCase
+from scripts.eval.runner import run_case
+from scripts.retrieval.lexical_index import build_chunk_index
+
+
+def _make_chunk_dir(tmp_path: Path) -> Path:
+    """Build a tiny chunk index containing a single AoO chunk."""
+    chunk = {
+        "chunk_id": "chunk::srd_35::combat::001_attack_of_opportunity",
+        "document_id": "srd_35::combat",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat: Attacks of Opportunity", "Movement"],
+            "source_location": "CombatI.rtf#001",
+        },
+        "chunk_type": "rule_section",
+        "content": (
+            "A character provokes an attack of opportunity when leaving a "
+            "threatened square through movement."
+        ),
+    }
+    chunk_path = tmp_path / "aoo.json"
+    chunk_path.write_text(json.dumps(chunk), encoding="utf-8")
+    db_path = tmp_path / "lexical.db"
+    build_chunk_index(db_path, [chunk_path])
+    return db_path
+
+
+def test_runner_grounded_clean_case(tmp_path: Path):
+    db_path = _make_chunk_dir(tmp_path)
+    case = GoldCase(
+        eval_id="P1-T-001",
+        question="When does a character provoke an attack of opportunity?",
+        question_type="direct_lookup",
+        expected_source_ids=("srd_35",),
+        expected_section_or_entry=(
+            "Combat: Attacks of Opportunity",
+            "Movement",
+        ),
+        expected_behavior="direct_answer",
+        expected_answer_notes="",
+    )
+    outcome = run_case(case, db_path=db_path, top_k=5)
+    assert outcome.eval_id == "P1-T-001"
+    assert outcome.actual_answer_type == "grounded"
+    # All citations match → clean tags.
+    assert outcome.tags == ()
+    assert outcome.diagnostics["total_candidates"] >= 1
+
+
+def test_runner_abstain_case_against_unrelated_query(tmp_path: Path):
+    db_path = _make_chunk_dir(tmp_path)
+    case = GoldCase(
+        eval_id="P1-IE-001",
+        question="What are Artificer infusion slots at level 5?",
+        question_type="insufficient_evidence",
+        expected_source_ids=(),
+        expected_section_or_entry=(),
+        expected_behavior="abstain",
+        expected_answer_notes="",
+    )
+    outcome = run_case(case, db_path=db_path, top_k=5)
+    # Index has no Artificer content → retrieve_evidence returns empty →
+    # build_answer abstains.
+    assert outcome.actual_answer_type == "abstain"
+    assert outcome.tags == ()  # behavior matches expected abstain
+    assert outcome.diagnostics["abstention_code"] in {
+        "empty_evidence", "weak_signals"
+    }
+
+
+def test_runner_grounded_when_abstain_expected(tmp_path: Path):
+    db_path = _make_chunk_dir(tmp_path)
+    # Question matches the only chunk, but the gold case expects abstain.
+    case = GoldCase(
+        eval_id="P1-IE-X",
+        question="When does a character provoke an attack of opportunity?",
+        question_type="insufficient_evidence",
+        expected_source_ids=(),
+        expected_section_or_entry=(),
+        expected_behavior="abstain",
+        expected_answer_notes="",
+    )
+    outcome = run_case(case, db_path=db_path, top_k=5)
+    if outcome.actual_answer_type == "grounded":
+        assert "missing_abstain" in outcome.tags
+        # Section/entry checks short-circuited for empty expected list.
+        for check in outcome.citation_checks:
+            assert check.section_match is None
+            assert check.entry_match is None

--- a/tests/test_eval_tagger.py
+++ b/tests/test_eval_tagger.py
@@ -1,0 +1,231 @@
+"""Tests for ``scripts.eval.tagger``."""
+from __future__ import annotations
+
+from scripts.answer.contracts import (
+    Abstention,
+    AnswerSegment,
+    Citation,
+    GroundedAnswer,
+)
+from scripts.eval.contracts import GoldCase
+from scripts.eval.tagger import tag_case
+from scripts.retrieval.contracts import NormalizedQuery
+from scripts.retrieval.evidence_pack import EvidencePack, PipelineTrace
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pack(query: str = "attack of opportunity") -> EvidencePack:
+    norm = NormalizedQuery(
+        raw_query=query,
+        normalized_text=query,
+        tokens=query.split(),
+        protected_phrases=[],
+        aliases_applied=[],
+    )
+    return EvidencePack(
+        query=norm,
+        constraints_summary={},
+        evidence=(),
+        trace=PipelineTrace(total_candidates=0, group_count=0, group_summaries=()),
+    )
+
+
+def _make_case(
+    *,
+    eval_id: str = "P1-T-001",
+    question: str = "When does a character provoke an attack of opportunity?",
+    expected_source_ids: tuple[str, ...] = ("srd_35",),
+    expected_section_or_entry: tuple[str, ...] = (
+        "Combat: Attacks of Opportunity",
+        "Movement",
+    ),
+    expected_behavior: str = "direct_answer",
+) -> GoldCase:
+    return GoldCase(
+        eval_id=eval_id,
+        question=question,
+        question_type="direct_lookup",
+        expected_source_ids=expected_source_ids,
+        expected_section_or_entry=expected_section_or_entry,
+        expected_behavior=expected_behavior,  # type: ignore[arg-type]
+        expected_answer_notes="",
+    )
+
+
+def _make_citation(
+    citation_id: str = "cit_1",
+    *,
+    source_id: str = "srd_35",
+    edition: str = "3.5e",
+    section_path: tuple[str, ...] = (
+        "Combat: Attacks of Opportunity",
+        "Movement",
+    ),
+    entry_title: str | None = None,
+    excerpt: str = (
+        "A character provokes an attack of opportunity when leaving a "
+        "threatened square through movement."
+    ),
+) -> Citation:
+    return Citation(
+        citation_id=citation_id,
+        chunk_id=f"chunk::{citation_id}",
+        source_ref={
+            "source_id": source_id,
+            "title": "System Reference Document",
+            "edition": edition,
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        locator={
+            "section_path": list(section_path),
+            **({"entry_title": entry_title} if entry_title else {}),
+        },
+        excerpt=excerpt,
+    )
+
+
+def _make_grounded(
+    citations: tuple[Citation, ...],
+    *,
+    primary_support_type: str = "direct_support",
+) -> GroundedAnswer:
+    cit_ids = tuple(c.citation_id for c in citations)
+    seg = AnswerSegment(
+        segment_id="seg_1",
+        text="primary excerpt",
+        support_type=primary_support_type,  # type: ignore[arg-type]
+        citation_ids=cit_ids,
+    )
+    return GroundedAnswer(
+        query="q", segments=(seg,), citations=citations
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-tag tests
+# ---------------------------------------------------------------------------
+
+
+def test_retrieval_miss_grounded_with_wrong_source():
+    case = _make_case()
+    cit = _make_citation(source_id="other_book")
+    result = _make_grounded((cit,))
+    tags, _ = tag_case(case, result, _make_pack())
+    assert "retrieval_miss" in tags
+
+
+def test_wrong_section_takes_precedence_over_wrong_entry():
+    case = _make_case()
+    # Right source, but section_path is in a totally different area.
+    cit = _make_citation(
+        section_path=("Spells", "Magic Missile"),
+    )
+    result = _make_grounded((cit,))
+    tags, _ = tag_case(case, result, _make_pack())
+    assert "wrong_section" in tags
+    assert "wrong_entry" not in tags
+
+
+def test_wrong_entry_when_section_root_matches_but_tail_does_not():
+    case = _make_case()
+    # Right section root ("Combat: Attacks of Opportunity") but a different entry.
+    cit = _make_citation(
+        section_path=("Combat: Attacks of Opportunity", "Threatened Squares"),
+    )
+    result = _make_grounded((cit,))
+    tags, _ = tag_case(case, result, _make_pack())
+    assert "wrong_entry" in tags
+    assert "wrong_section" not in tags
+
+
+def test_citation_mismatch_fires_independently_with_other_tags():
+    case = _make_case(question="When does a character provoke movement attacks?")
+    # Wrong source (retrieval_miss) AND excerpt has no overlap with question.
+    cit = _make_citation(
+        source_id="other_book",
+        excerpt="Fireball deals 1d6 fire damage per caster level.",
+    )
+    result = _make_grounded((cit,))
+    tags, checks = tag_case(case, result, _make_pack())
+    assert "retrieval_miss" in tags
+    assert "citation_mismatch" in tags
+    assert checks[0].citation_mismatch is True
+
+
+def test_unsupported_inference_fires_when_expected_direct():
+    case = _make_case(expected_behavior="direct_answer")
+    cit = _make_citation()
+    result = _make_grounded((cit,), primary_support_type="supported_inference")
+    tags, _ = tag_case(case, result, _make_pack())
+    assert "unsupported_inference" in tags
+
+
+def test_unsupported_inference_does_not_fire_when_expected_supported():
+    case = _make_case(expected_behavior="supported_inference")
+    cit = _make_citation()
+    result = _make_grounded((cit,), primary_support_type="supported_inference")
+    tags, _ = tag_case(case, result, _make_pack())
+    assert "unsupported_inference" not in tags
+
+
+def test_missing_abstain_when_grounded_but_should_abstain():
+    case = _make_case(
+        expected_source_ids=(),
+        expected_section_or_entry=(),
+        expected_behavior="abstain",
+    )
+    cit = _make_citation()
+    result = _make_grounded((cit,))
+    tags, _ = tag_case(case, result, _make_pack())
+    assert "missing_abstain" in tags
+
+
+def test_unnecessary_abstain_when_abstained_but_should_ground():
+    case = _make_case()
+    result = Abstention(
+        query="q",
+        reason="Insufficient evidence: no chunks retrieved for this query.",
+        trigger_code="empty_evidence",
+    )
+    tags, _ = tag_case(case, result, _make_pack())
+    assert "unnecessary_abstain" in tags
+
+
+def test_edition_boundary_failure_when_wrong_edition_cited():
+    case = _make_case()
+    cit = _make_citation(edition="5e")
+    result = _make_grounded((cit,))
+    tags, _ = tag_case(case, result, _make_pack())
+    assert "edition_boundary_failure" in tags
+
+
+def test_empty_expected_section_short_circuits_section_and_entry_tags():
+    # Abstain-shaped gold case but the model produced grounded — only the
+    # behavior-mismatch and citation-content tags should be considered;
+    # section/entry must NOT fire and the per-citation matches are None.
+    case = _make_case(
+        expected_source_ids=(),
+        expected_section_or_entry=(),
+        expected_behavior="abstain",
+    )
+    cit = _make_citation()
+    result = _make_grounded((cit,))
+    tags, checks = tag_case(case, result, _make_pack())
+    assert "wrong_section" not in tags
+    assert "wrong_entry" not in tags
+    for c in checks:
+        assert c.section_match is None
+        assert c.entry_match is None
+
+
+def test_clean_case_emits_no_tags():
+    case = _make_case()
+    cit = _make_citation()  # right source, section, entry, edition, overlap
+    result = _make_grounded((cit,))
+    tags, _ = tag_case(case, result, _make_pack())
+    assert tags == ()


### PR DESCRIPTION
## Summary

Implements the Phase 1 regression-eval harness designed in #79 (merged at \`2b935ab\`). Loads \`evals/phase1_gold.yaml\`, runs \`build_answer(retrieve_evidence(question))\` per case, classifies outcomes with eight interpretable failure tags, writes paired JSON + Markdown reports under \`evals/reports/\`. Reporter, not a CI gate; exits 0 regardless of tag counts.

Closes #24. Combined with merged #23, contributes the last blocker for rollup **#5**.

## First real signal — meaningful

Run against the real SRD index, committed as \`evals/reports/phase1_gold_latest.{json,md}\`:

| Tag | Count | Notes |
|---|---|---|
| \`unnecessary_abstain\` | **15** | Half the gold set. \`assess_support\`'s strict-signal gate (#23) is too tight for real query phrasing. Spec called this out as the policy-A tradeoff to measure first. |
| \`wrong_section\` | **9** | Gold set encodes section roots as \`Combat: Attacks of Opportunity\` while chunked locators carry \`CombatI\`. Spec §3.3's colon-prefix tolerance still isn't generous enough; explicitly anticipated to be tightened after #60. |
| \`citation_mismatch\` | 1 | Per-citation token-overlap heuristic, low-volume. |
| \`missing_abstain\` | 1 | One case where we grounded but should have abstained. |
| \`retrieval_miss\` | 0 | Source-id constraints holding. |
| \`wrong_entry\` | 0 | (Most cases get \`wrong_section\` first; that suppresses \`wrong_entry\` per §3.3.) |
| \`unsupported_inference\` | 0 | |
| \`edition_boundary_failure\` | 0 | Hard filters in \`scripts/retrieval/filters.py\` doing their job. |
| **\`_clean\`** | **5** | 1 grounded + 4 abstain. |

**Behavior match rate: 0.47.**

This is exactly the data the eval harness is designed to surface. Two clear follow-up directions:
1. Loosen the abstain gate (#23 successor work — we now have a baseline to compare against).
2. Tighten the wrong_section tolerance after #60 lands hierarchical chunking, and/or normalize the gold set's section labels.

## Two commits

1. **\`77ea4ba\`** — \`test(answer)\`: hygiene fix repairing fixture helpers in 4 \`test_answer_*.py\` files. PR #72 (adjacent-chunk consolidation) added 7 required fields to \`EvidenceItem\` and 1 to \`GroupSummary\` without defaults, breaking 17 existing tests on master. Carved out as its own commit so this PR can honestly claim a clean test baseline.
2. **\`148569f\`** — \`feat(eval)\`: the harness itself, per the merged spec.

## Implementation notes

- All 8 tags from spec §3.2 implemented exactly per the trigger conditions.
- Empty \`expected_section_or_entry\` short-circuits both the matcher (§3.3) and the tagger; \`section_match\`/\`entry_match\` return \`None\` (rendered as \`n/a\` in the markdown).
- \`citation_mismatch\` fires independently of other tags per the addressed review feedback.
- \`wrong_section\` suppresses \`wrong_entry\` per §3.3.
- Module layout: \`scripts/eval/\` (contracts, loader, matching, tagger, runner, report) + \`scripts/run_phase1_eval.py\` CLI. Mirrors \`scripts/answer/\` style.
- 36 new tests, all passing. Full suite: 271 passed, 1 xfailed, 1 unrelated pre-existing FileNotFoundError in \`test_ingest_srd_35\`.

## Self-noted minor deviations from spec

- Lexical index built ad-hoc via \`python -c \"from scripts.retrieval.lexical_index import build_chunk_index\"\` because \`scripts/chunk_srd_35.py\` only does canonical→chunks (it does not build the lexical index). Spec didn't anticipate this gap. Worth a follow-up: add a \`scripts/build_index_srd_35.py\` entry point.
- \`scripts/eval/tagger.py\` and \`scripts/eval/report.py\` each carry their own \`_TAG_ORDER\` tuple. Could be DRY'd up; left as-is to keep \`report.py\` independent of the tagger module.
- Filtered out \`chunk_report.json\` (an ingestion metadata file, not a chunk) when feeding the index builder.

## Test plan

- [x] 36 new eval tests passing
- [x] Full suite passing (271/272 — the 1 failure is unrelated pre-existing)
- [x] Real run against the SRD index, both reports committed under \`evals/reports/\` as PR evidence per \`docs/standards/pr_evidence.md\`
- [x] \`evals/README.md\` carries the rerun command
- [ ] Follow-up issue: loosen abstain gate after reviewing the 15 \`unnecessary_abstain\` cases
- [ ] Follow-up issue: build_index_srd_35.py entry point (gap surfaced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)