### PR TITLE
feat(retrieval): add evidence_pack.schema.json and validate via tests

### DIFF
--- a/examples/evidence_pack.example.json
+++ b/examples/evidence_pack.example.json
@@ -29,7 +29,8 @@
       {
         "document_id": "srd_35::combat",
         "section_root": "Combat",
-        "candidate_count": 2
+        "candidate_count": 2,
+        "span_count": 2
       }
     ]
   },
@@ -66,6 +67,19 @@
         "section_path_hit": true,
         "token_overlap_count": 3
       },
+      "span": {
+        "chunk_ids": [
+          "srd_35::combat::attack_of_opportunity::chunk_2"
+        ],
+        "start_chunk_id": "srd_35::combat::attack_of_opportunity::chunk_2",
+        "end_chunk_id": "srd_35::combat::attack_of_opportunity::chunk_2",
+        "merge_reason": "singleton"
+      },
+      "adjacency": {
+        "parent_chunk_id": null,
+        "previous_chunk_id": null,
+        "next_chunk_id": null
+      },
       "content": "You threaten all squares into which you can make a melee attack, even when it is not your turn. Generally, that means everything in all squares adjacent to your space."
     },
     {
@@ -98,6 +112,19 @@
         ],
         "section_path_hit": true,
         "token_overlap_count": 3
+      },
+      "span": {
+        "chunk_ids": [
+          "srd_35::combat::attack_of_opportunity::chunk_1"
+        ],
+        "start_chunk_id": "srd_35::combat::attack_of_opportunity::chunk_1",
+        "end_chunk_id": "srd_35::combat::attack_of_opportunity::chunk_1",
+        "merge_reason": "singleton"
+      },
+      "adjacency": {
+        "parent_chunk_id": null,
+        "previous_chunk_id": null,
+        "next_chunk_id": null
       },
       "content": "Sometimes a combatant in a melee lets her guard down or takes a reckless action. In this case, combatants near her can take advantage of her lapse in defense to attack her for free. These free attacks are called attacks of opportunity."
     }

--- a/schemas/evidence_pack.schema.json
+++ b/schemas/evidence_pack.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "EvidencePack",
-  "description": "Retrieval-to-answer handoff contract. Wraps the consolidated retrieval output (shaped + adjacent-chunk consolidated candidates) with chunk content, query context, constraint summary, and a pipeline trace. This schema validates the JSON shape emitted by scripts/retrieve_debug.py --json.",
+  "description": "Retrieval-to-answer handoff contract. Wraps the consolidated retrieval output (shaped + adjacent-chunk consolidated candidates) with chunk content, query context, constraint summary, and a pipeline trace. This schema validates the structural shape of the JSON emitted by scripts/retrieve_debug.py --json. Cross-field ID-consistency invariants (chunk_ids[0] == start_chunk_id, chunk_ids[-1] == end_chunk_id, and chunk_ids == [chunk_id] when merge_reason is 'singleton') are producer-side guarantees from build_evidence_pack and are not expressible in Draft-07 JSON Schema; consumers needing those guarantees should mirror the assertion helper in tests/test_evidence_pack_schema.py:_assert_span_invariants.",
   "type": "object",
   "required": ["query", "constraints", "trace", "evidence"],
   "additionalProperties": false,
@@ -163,7 +163,7 @@
           },
           "chunk_id": {
             "type": "string",
-            "description": "Representative chunk_id for this evidence item. Equal to span.start_chunk_id and span.end_chunk_id when merge_reason is 'singleton'; for adjacent_span items the representative is the best-ranked chunk in the span and need not equal start or end."
+            "description": "Representative chunk_id for this evidence item. By producer convention (not enforced by this schema): equal to span.start_chunk_id and span.end_chunk_id, and to span.chunk_ids[0], when merge_reason is 'singleton'. For adjacent_span items the representative is the best-ranked chunk in the span and need not equal start or end."
           },
           "document_id": {
             "type": "string",
@@ -243,7 +243,7 @@
                 "type": "array",
                 "items": { "type": "string" },
                 "minItems": 1,
-                "description": "All chunk_ids in the span, in reading order. chunk_ids[0] == start_chunk_id and chunk_ids[-1] == end_chunk_id."
+                "description": "All chunk_ids in the span, in reading order. By producer convention (not enforced by this schema): chunk_ids[0] == start_chunk_id and chunk_ids[-1] == end_chunk_id."
               },
               "start_chunk_id": {
                 "type": "string",

--- a/schemas/evidence_pack.schema.json
+++ b/schemas/evidence_pack.schema.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "EvidencePack",
+  "description": "Retrieval-to-answer handoff contract. Wraps the consolidated retrieval output (shaped + adjacent-chunk consolidated candidates) with chunk content, query context, constraint summary, and a pipeline trace. This schema validates the JSON shape emitted by scripts/retrieve_debug.py --json.",
+  "type": "object",
+  "required": ["query", "constraints", "trace", "evidence"],
+  "additionalProperties": false,
+  "properties": {
+    "query": {
+      "type": "object",
+      "description": "Normalized query context as produced by query_normalization.",
+      "required": [
+        "raw",
+        "normalized",
+        "tokens",
+        "protected_phrases",
+        "aliases_applied"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "raw": {
+          "type": "string",
+          "description": "The original user query string."
+        },
+        "normalized": {
+          "type": "string",
+          "description": "Normalized query text after alias expansion and protected-phrase preservation."
+        },
+        "tokens": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Tokens passed to the FTS expression. Each protected phrase appears as a single token."
+        },
+        "protected_phrases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Phrases preserved as a single token through tokenisation."
+        },
+        "aliases_applied": {
+          "type": "array",
+          "description": "Alias expansions applied during normalization.",
+          "items": {
+            "type": "object",
+            "required": ["source", "target"],
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "string",
+                "description": "The alias as written in the raw query."
+              },
+              "target": {
+                "type": "string",
+                "description": "The canonical phrase the alias was expanded to."
+              }
+            }
+          }
+        }
+      }
+    },
+    "constraints": {
+      "type": "object",
+      "description": "Hard filters applied during retrieval. Empty arrays mean no filtering on that axis.",
+      "required": [
+        "editions",
+        "source_types",
+        "authority_levels",
+        "excluded_source_ids"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "editions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Allowed edition labels (e.g. \"3.5e\")."
+        },
+        "source_types": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Allowed source_type values from the source registry."
+        },
+        "authority_levels": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Allowed authority_level values from the source registry."
+        },
+        "excluded_source_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "source_id values explicitly excluded from retrieval."
+        }
+      }
+    },
+    "trace": {
+      "type": "object",
+      "description": "Diagnostic snapshot of the retrieval pipeline.",
+      "required": ["total_candidates", "group_count", "groups"],
+      "additionalProperties": false,
+      "properties": {
+        "total_candidates": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of LexicalCandidate objects that entered the shaping layer."
+        },
+        "group_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of (document_id, section_root) groups produced by shape_candidates()."
+        },
+        "groups": {
+          "type": "array",
+          "description": "Per-group summary of how many candidates entered the group and how many spans came out after adjacent-chunk consolidation.",
+          "items": {
+            "type": "object",
+            "required": [
+              "document_id",
+              "section_root",
+              "candidate_count",
+              "span_count"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "document_id": { "type": "string" },
+              "section_root": { "type": "string" },
+              "candidate_count": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "LexicalCandidates that entered this group."
+              },
+              "span_count": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "EvidenceSpans produced after adjacent-chunk consolidation. Equal to candidate_count when nothing collapsed; lower when adjacent hits merged."
+              }
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "description": "Evidence items in global rank order (best-ranked first). One item per EvidenceSpan; for multi-chunk spans the representative carries the content and the other chunk_ids appear under span.chunk_ids.",
+      "items": {
+        "type": "object",
+        "required": [
+          "rank",
+          "chunk_id",
+          "document_id",
+          "chunk_type",
+          "section_root",
+          "source_ref",
+          "locator",
+          "match_signals",
+          "span",
+          "adjacency",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "rank": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Global rank of the representative chunk after composite scoring."
+          },
+          "chunk_id": {
+            "type": "string",
+            "description": "Representative chunk_id for this evidence item. Equal to span.start_chunk_id and span.end_chunk_id when merge_reason is 'singleton'; for adjacent_span items the representative is the best-ranked chunk in the span and need not equal start or end."
+          },
+          "document_id": {
+            "type": "string",
+            "description": "Document the representative chunk belongs to."
+          },
+          "chunk_type": {
+            "type": "string",
+            "enum": [
+              "rule_section",
+              "subsection",
+              "spell_entry",
+              "feat_entry",
+              "skill_entry",
+              "class_feature",
+              "condition_entry",
+              "glossary_entry",
+              "table",
+              "example",
+              "sidebar",
+              "errata_note",
+              "faq_note",
+              "paragraph_group",
+              "generic"
+            ],
+            "description": "Semantic chunk type of the representative chunk. Mirrors chunk.schema.json#/properties/chunk_type."
+          },
+          "section_root": {
+            "type": "string",
+            "description": "Top-level section heading the group is rooted at (locator.section_path[0])."
+          },
+          "source_ref": {
+            "$ref": "./common.schema.json#/$defs/sourceRef"
+          },
+          "locator": {
+            "$ref": "./common.schema.json#/$defs/locator"
+          },
+          "match_signals": {
+            "type": "object",
+            "description": "Lexical match signals extracted from the representative chunk against the normalized query.",
+            "required": [
+              "exact_phrase_hits",
+              "protected_phrase_hits",
+              "section_path_hit",
+              "token_overlap_count"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "exact_phrase_hits": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "protected_phrase_hits": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "section_path_hit": {
+                "type": "boolean"
+              },
+              "token_overlap_count": {
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          },
+          "span": {
+            "type": "object",
+            "description": "Adjacent-chunk consolidation metadata. A singleton item has chunk_ids of length 1 and merge_reason 'singleton'; an adjacent_span item has multiple chunk_ids in reading order with merge_reason 'adjacent_span'.",
+            "required": [
+              "chunk_ids",
+              "start_chunk_id",
+              "end_chunk_id",
+              "merge_reason"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "chunk_ids": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 1,
+                "description": "All chunk_ids in the span, in reading order. chunk_ids[0] == start_chunk_id and chunk_ids[-1] == end_chunk_id."
+              },
+              "start_chunk_id": {
+                "type": "string",
+                "description": "First chunk in the span, in reading order."
+              },
+              "end_chunk_id": {
+                "type": "string",
+                "description": "Last chunk in the span, in reading order."
+              },
+              "merge_reason": {
+                "type": "string",
+                "enum": ["singleton", "adjacent_span"],
+                "description": "Why the span has its current shape. New reasons (e.g. 'near_duplicate') will be added when consolidation gains those passes."
+              }
+            }
+          },
+          "adjacency": {
+            "type": "object",
+            "description": "Structural adjacency links for the representative chunk, passed through from the index. Null when the representative has no parent / is first / is last.",
+            "required": [
+              "parent_chunk_id",
+              "previous_chunk_id",
+              "next_chunk_id"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "parent_chunk_id": { "type": ["string", "null"] },
+              "previous_chunk_id": { "type": ["string", "null"] },
+              "next_chunk_id": { "type": ["string", "null"] }
+            }
+          },
+          "content": {
+            "type": "string",
+            "description": "Hydrated text content of the representative chunk. Multi-chunk spans do NOT concatenate content here; the other chunk_ids in the span are metadata and content assembly is the answer-side concern."
+          }
+        },
+        "allOf": [
+          {
+            "comment": "When merge_reason is 'singleton', span.chunk_ids must have exactly one entry equal to chunk_id, start_chunk_id, and end_chunk_id.",
+            "if": {
+              "properties": {
+                "span": {
+                  "properties": {
+                    "merge_reason": { "const": "singleton" }
+                  }
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "span": {
+                  "properties": {
+                    "chunk_ids": { "maxItems": 1, "minItems": 1 }
+                  }
+                }
+              }
+            }
+          },
+          {
+            "comment": "When merge_reason is 'adjacent_span', span.chunk_ids must have at least two entries.",
+            "if": {
+              "properties": {
+                "span": {
+                  "properties": {
+                    "merge_reason": { "const": "adjacent_span" }
+                  }
+                }
+              }
+            },
+            "then": {
+              "properties": {
+                "span": {
+                  "properties": {
+                    "chunk_ids": { "minItems": 2 }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_evidence_pack_schema.py
+++ b/tests/test_evidence_pack_schema.py
@@ -30,6 +30,36 @@ _SCHEMAS_DIR = _REPO_ROOT / "schemas"
 _EXAMPLES_DIR = _REPO_ROOT / "examples"
 
 
+def _assert_span_invariants(payload: dict) -> None:
+    """Cross-field ID-consistency invariants that JSON Schema can't enforce.
+
+    These are producer-side guarantees from build_evidence_pack — schema
+    validation alone is not sufficient for downstream code (e.g. citation
+    rendering) that depends on ID consistency. Mirror this helper from
+    consumer code paths whenever you load an evidence pack from JSON
+    rather than constructing it in-process.
+    """
+    for i, item in enumerate(payload["evidence"]):
+        span = item["span"]
+        chunk_ids = span["chunk_ids"]
+        path = f"evidence[{i}]"
+
+        assert chunk_ids[0] == span["start_chunk_id"], (
+            f"{path}: span.chunk_ids[0]={chunk_ids[0]!r} != "
+            f"start_chunk_id={span['start_chunk_id']!r}"
+        )
+        assert chunk_ids[-1] == span["end_chunk_id"], (
+            f"{path}: span.chunk_ids[-1]={chunk_ids[-1]!r} != "
+            f"end_chunk_id={span['end_chunk_id']!r}"
+        )
+
+        if span["merge_reason"] == "singleton":
+            assert chunk_ids == [item["chunk_id"]], (
+                f"{path}: singleton span.chunk_ids={chunk_ids!r} != "
+                f"[chunk_id={item['chunk_id']!r}]"
+            )
+
+
 def _make_validator() -> Draft7Validator:
     main = json.loads(
         (_SCHEMAS_DIR / "evidence_pack.schema.json").read_text(encoding="utf-8")
@@ -89,6 +119,15 @@ def test_committed_example_validates():
     )
 
 
+def test_committed_example_passes_runtime_invariants():
+    """The committed example must also satisfy the cross-field ID
+    consistency invariants the schema cannot express."""
+    payload = json.loads(
+        (_EXAMPLES_DIR / "evidence_pack.example.json").read_text(encoding="utf-8")
+    )
+    _assert_span_invariants(payload)
+
+
 # ---------------------------------------------------------------------------
 # Live debug-CLI output must validate
 # ---------------------------------------------------------------------------
@@ -114,6 +153,26 @@ def test_live_to_json_output_validates_singleton(tmp_path):
     assert errors == [], f"Live output failed validation:\n  " + "\n  ".join(
         f"{list(err.absolute_path)}: {err.message}" for err in errors
     )
+
+
+def test_live_to_json_output_passes_runtime_invariants(tmp_path):
+    """A live retrieve_evidence -> _to_json round-trip also satisfies the
+    runtime ID-consistency invariants. Pins build_evidence_pack's producer
+    behaviour."""
+    chunk_path = tmp_path / "aoo.json"
+    chunk_path.write_text(
+        json.dumps(_aoo_chunk(
+            "chunk::srd_35::combat::001_aoo",
+            "An attack of opportunity is a single melee attack.",
+        )),
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "retrieval.db"
+    build_chunk_index(db_path, [chunk_path])
+
+    pack = retrieve_evidence("attack of opportunity", db_path=db_path, top_k=5)
+    payload = _to_json(pack)
+    _assert_span_invariants(payload)
 
 
 def test_live_to_json_output_validates_adjacent_span(tmp_path):
@@ -222,3 +281,87 @@ def test_rejects_rank_zero():
     payload["evidence"][0]["rank"] = 0
     errors = list(_make_validator().iter_errors(payload))
     assert errors, "schema should reject rank < 1"
+
+
+def test_rejects_unknown_nested_key():
+    """additionalProperties: false applies at every level — extra keys
+    inside nested objects must also be rejected."""
+    payload = _good_payload()
+    payload["evidence"][0]["span"]["surprise"] = "extra"
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject unknown keys nested inside span"
+
+
+# ---------------------------------------------------------------------------
+# Runtime invariants — cross-field ID consistency that JSON Schema can't enforce
+# ---------------------------------------------------------------------------
+
+
+def test_invariants_reject_singleton_with_mismatched_chunk_id():
+    """Singleton item where chunk_id doesn't match span.chunk_ids[0].
+
+    This is the case the auto-review flagged: schema-passes-but-broken.
+    The schema (length-only) accepts it; the runtime helper must reject."""
+    payload = _good_payload()
+    item = payload["evidence"][0]
+    # Force a singleton-shaped span with mismatched representative chunk_id.
+    item["span"]["merge_reason"] = "singleton"
+    item["span"]["chunk_ids"] = ["other_chunk"]
+    item["span"]["start_chunk_id"] = "other_chunk"
+    item["span"]["end_chunk_id"] = "other_chunk"
+    # item["chunk_id"] left as the original real chunk_id from the example.
+
+    # Schema validation passes (this is the gap).
+    assert list(_make_validator().iter_errors(payload)) == []
+
+    # Runtime invariants do NOT.
+    try:
+        _assert_span_invariants(payload)
+    except AssertionError as err:
+        assert "singleton" in str(err)
+    else:
+        raise AssertionError(
+            "_assert_span_invariants should have rejected mismatched singleton IDs"
+        )
+
+
+def test_invariants_reject_chunk_ids_first_not_equal_start():
+    """span.chunk_ids[0] must equal start_chunk_id."""
+    payload = _good_payload()
+    item = payload["evidence"][0]
+    item["span"]["chunk_ids"] = ["unrelated"]
+    item["span"]["start_chunk_id"] = "different"
+    item["span"]["end_chunk_id"] = "unrelated"
+    # Make merge_reason 'adjacent_span' so this isn't also a singleton failure;
+    # length still 1 so schema rejects it under the singleton/adjacent-span
+    # conditional. Use a 2-element form to isolate the chunk_ids[0] vs
+    # start_chunk_id check.
+    item["span"]["chunk_ids"] = ["unrelated", item["span"]["end_chunk_id"]]
+    item["span"]["merge_reason"] = "adjacent_span"
+
+    try:
+        _assert_span_invariants(payload)
+    except AssertionError as err:
+        assert "chunk_ids[0]" in str(err)
+    else:
+        raise AssertionError(
+            "_assert_span_invariants should reject chunk_ids[0] != start_chunk_id"
+        )
+
+
+def test_invariants_reject_chunk_ids_last_not_equal_end():
+    """span.chunk_ids[-1] must equal end_chunk_id."""
+    payload = _good_payload()
+    item = payload["evidence"][0]
+    item["span"]["chunk_ids"] = [item["span"]["start_chunk_id"], "unrelated_end"]
+    item["span"]["merge_reason"] = "adjacent_span"
+    # end_chunk_id intentionally not updated to match chunk_ids[-1].
+
+    try:
+        _assert_span_invariants(payload)
+    except AssertionError as err:
+        assert "chunk_ids[-1]" in str(err)
+    else:
+        raise AssertionError(
+            "_assert_span_invariants should reject chunk_ids[-1] != end_chunk_id"
+        )

--- a/tests/test_evidence_pack_schema.py
+++ b/tests/test_evidence_pack_schema.py
@@ -1,0 +1,224 @@
+"""Validates the evidence-pack JSON contract against schemas/evidence_pack.schema.json.
+
+The schema is the canonical handoff format between retrieval and answer
+generation. These tests pin three things:
+
+1. The committed example artifact validates.
+2. A live debug-CLI JSON payload (built end-to-end via retrieve_evidence
+   over a tmp index) validates — guards against drift between the schema
+   and the actual code path.
+3. A few targeted negative cases: known-bad payloads must fail
+   validation, so the schema is actually enforcing the invariants.
+"""
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT7
+
+from scripts.retrieval.evidence_pack import retrieve_evidence
+from scripts.retrieval.lexical_index import build_chunk_index
+from scripts.retrieve_debug import _to_json
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCHEMAS_DIR = _REPO_ROOT / "schemas"
+_EXAMPLES_DIR = _REPO_ROOT / "examples"
+
+
+def _make_validator() -> Draft7Validator:
+    main = json.loads(
+        (_SCHEMAS_DIR / "evidence_pack.schema.json").read_text(encoding="utf-8")
+    )
+    common = json.loads(
+        (_SCHEMAS_DIR / "common.schema.json").read_text(encoding="utf-8")
+    )
+    common_resource = Resource.from_contents(common, default_specification=DRAFT7)
+    registry = Registry().with_resources(
+        [
+            ("./common.schema.json", common_resource),
+            ("common.schema.json", common_resource),
+        ]
+    )
+    return Draft7Validator(main, registry=registry)
+
+
+def _aoo_chunk(chunk_id: str, content: str, **extra: object) -> dict:
+    chunk = {
+        "chunk_id": chunk_id,
+        "document_id": "srd_35::combat",
+        "source_ref": {
+            "source_id": "srd_35",
+            "title": "System Reference Document",
+            "edition": "3.5e",
+            "source_type": "srd",
+            "authority_level": "official_reference",
+        },
+        "locator": {
+            "section_path": ["Combat", "Attack of Opportunity"],
+            "source_location": "Combat.rtf#001",
+        },
+        "chunk_type": "rule_section",
+        "content": content,
+    }
+    chunk.update(extra)
+    return chunk
+
+
+# ---------------------------------------------------------------------------
+# The committed example must validate
+# ---------------------------------------------------------------------------
+
+
+def test_committed_example_validates():
+    """examples/evidence_pack.example.json must validate against the schema.
+
+    If this fails, either the example was not regenerated after a schema
+    change, or the schema is wrong.
+    """
+    payload = json.loads(
+        (_EXAMPLES_DIR / "evidence_pack.example.json").read_text(encoding="utf-8")
+    )
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors == [], f"Example failed validation:\n  " + "\n  ".join(
+        f"{list(err.absolute_path)}: {err.message}" for err in errors
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live debug-CLI output must validate
+# ---------------------------------------------------------------------------
+
+
+def test_live_to_json_output_validates_singleton(tmp_path):
+    """A real retrieve_evidence -> _to_json round-trip validates."""
+    chunk_path = tmp_path / "aoo.json"
+    chunk_path.write_text(
+        json.dumps(_aoo_chunk(
+            "chunk::srd_35::combat::001_aoo",
+            "An attack of opportunity is a single melee attack.",
+        )),
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "retrieval.db"
+    build_chunk_index(db_path, [chunk_path])
+
+    pack = retrieve_evidence("attack of opportunity", db_path=db_path, top_k=5)
+    payload = _to_json(pack)
+
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors == [], f"Live output failed validation:\n  " + "\n  ".join(
+        f"{list(err.absolute_path)}: {err.message}" for err in errors
+    )
+
+
+def test_live_to_json_output_validates_adjacent_span(tmp_path):
+    """A multi-chunk adjacent_span end-to-end also validates."""
+    a = _aoo_chunk(
+        "chunk::srd_35::combat::001_a",
+        "Attack of opportunity first half — the trigger conditions.",
+        next_chunk_id="chunk::srd_35::combat::002_b",
+    )
+    b = _aoo_chunk(
+        "chunk::srd_35::combat::002_b",
+        "Attack of opportunity second half — the damage resolution.",
+        previous_chunk_id="chunk::srd_35::combat::001_a",
+    )
+    path_a = tmp_path / "a.json"
+    path_b = tmp_path / "b.json"
+    path_a.write_text(json.dumps(a), encoding="utf-8")
+    path_b.write_text(json.dumps(b), encoding="utf-8")
+    db_path = tmp_path / "retrieval.db"
+    build_chunk_index(db_path, [path_a, path_b])
+
+    pack = retrieve_evidence("attack of opportunity", db_path=db_path, top_k=5)
+    payload = _to_json(pack)
+
+    # Sanity: the two chunks did consolidate into one adjacent_span item.
+    assert len(payload["evidence"]) == 1
+    assert payload["evidence"][0]["span"]["merge_reason"] == "adjacent_span"
+
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors == [], f"Live output failed validation:\n  " + "\n  ".join(
+        f"{list(err.absolute_path)}: {err.message}" for err in errors
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — schema must reject these
+# ---------------------------------------------------------------------------
+
+
+def _good_payload() -> dict:
+    """Returns a freshly-loaded copy of the example for mutation in tests."""
+    return json.loads(
+        (_EXAMPLES_DIR / "evidence_pack.example.json").read_text(encoding="utf-8")
+    )
+
+
+def test_rejects_missing_top_level_key():
+    payload = _good_payload()
+    del payload["trace"]
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject payload missing 'trace'"
+
+
+def test_rejects_unknown_top_level_key():
+    payload = _good_payload()
+    payload["surprise"] = "extra"
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject unknown top-level keys (additionalProperties: false)"
+
+
+def test_rejects_invalid_chunk_type():
+    payload = _good_payload()
+    payload["evidence"][0]["chunk_type"] = "not_a_real_type"
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject chunk_type values outside the enum"
+
+
+def test_rejects_invalid_merge_reason():
+    payload = _good_payload()
+    payload["evidence"][0]["span"]["merge_reason"] = "near_duplicate"  # not yet valid
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject merge_reason values outside the current enum"
+
+
+def test_rejects_singleton_with_multiple_chunk_ids():
+    """Conditional invariant: merge_reason='singleton' implies chunk_ids has length 1."""
+    payload = _good_payload()
+    item = payload["evidence"][0]
+    item["span"]["merge_reason"] = "singleton"
+    item["span"]["chunk_ids"] = ["a", "b"]
+    item["span"]["start_chunk_id"] = "a"
+    item["span"]["end_chunk_id"] = "b"
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject singleton spans with len(chunk_ids) > 1"
+
+
+def test_rejects_adjacent_span_with_single_chunk_id():
+    """Conditional invariant: merge_reason='adjacent_span' implies chunk_ids has length >= 2."""
+    payload = _good_payload()
+    item = payload["evidence"][0]
+    item["span"]["merge_reason"] = "adjacent_span"
+    # leave chunk_ids at length 1
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject adjacent_span with single-element chunk_ids"
+
+
+def test_rejects_negative_token_overlap_count():
+    payload = _good_payload()
+    payload["evidence"][0]["match_signals"]["token_overlap_count"] = -1
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject negative token_overlap_count"
+
+
+def test_rejects_rank_zero():
+    payload = _good_payload()
+    payload["evidence"][0]["rank"] = 0
+    errors = list(_make_validator().iter_errors(payload))
+    assert errors, "schema should reject rank < 1"


### PR DESCRIPTION
## Summary
Closes the schema gap flagged earlier on #5 — `EvidencePack` lived only as a Python dataclass, with no JSON Schema doc that an external consumer could validate against. This PR adds the schema, regenerates the (stale) example artifact, pins both via tests, and ships a runtime invariant helper for the cross-field ID-consistency invariants that Draft-07 JSON Schema cannot express.

- **`schemas/evidence_pack.schema.json`** — Draft-07. `$ref`s `./common.schema.json#/$defs/sourceRef` and `./common.schema.json#/$defs/locator`. `additionalProperties: false` at every level. Conditional invariants enforce the span-shape rule from PR #72: `merge_reason="singleton"` ⇔ `len(chunk_ids) == 1`, `merge_reason="adjacent_span"` ⇔ `len(chunk_ids) >= 2`. The schema description is explicit that cross-field ID equalities (`chunk_ids[0] == start_chunk_id`, `chunk_ids[-1] == end_chunk_id`, singleton's `chunk_ids == [chunk_id]`) are producer-side guarantees, not enforced by Draft-07, and points at the runtime helper.
- **`examples/evidence_pack.example.json`** — regenerated via `scripts/regen_examples.py`. The committed file predated PR #72 and was missing `trace.groups[].span_count` plus the per-evidence `span` and `adjacency` nested objects.
- **`tests/test_evidence_pack_schema.py`** — validates:
  - committed example shape,
  - live `retrieve_evidence → _to_json` output for both singleton and adjacent_span shapes,
  - schema-level negative cases (missing/unknown keys at top level *and* nested, invalid `chunk_type`, invalid `merge_reason`, singleton with multi-chunk_ids, adjacent_span with single chunk_id, negative `token_overlap_count`, `rank=0`),
  - **runtime span ID-consistency invariants** that Draft-07 JSON Schema cannot express (`_assert_span_invariants` helper, with positive coverage on the example + live output and negative coverage including the exact "schema accepts but invariant rejects" case the auto-review flagged).

## Why now
The eval harness (PR #81) and any future external `--json` consumer have no contract to validate against. Until this lands, the EvidencePack JSON shape is enforced only by Python dataclass construction inside the same process. With the schema + invariant helper, the hand-off is genuinely portable.

## Forward-compat notes
- The `merge_reason` enum is currently `["singleton", "adjacent_span"]`. When the near-duplicate work from #68 lands, that enum will need `"near_duplicate"` added — schema bump required at the same time.
- `chunk_type` enum is currently duplicated between this schema and `chunk.schema.json`. Tracked as a separate refactor in #87.
- The `_assert_span_invariants` helper sits in tests today. If/when answer-side or eval-side code starts loading evidence packs from JSON (rather than constructing in-process), the helper should be promoted into a real module — e.g. `scripts/retrieval/evidence_pack_validation.py` exposing `validate_evidence_pack_shape(payload)` + `assert_evidence_pack_invariants(payload)`. Acceptable as a test helper for now.

## Pre-existing failure surfaced (NOT caused by this PR)
Running the full suite reveals 28 unrelated pre-existing failures in `tests/test_answer_*` (and 1 in `test_ingest_srd_35`, the long-standing one). The 28 in the answer-side tests are caused by PR #72 adding 7 new required fields to `EvidenceItem` without backward-compatible defaults — PR #74's tests construct `EvidenceItem` directly and were not updated. Confirmed reproducible on clean `master` without my changes. Would suggest a separate fix-up issue.

## Test plan
- [x] `pytest tests/test_evidence_pack_schema.py -v` — all green
- [x] Schema validates the regenerated committed example
- [x] Schema validates a live end-to-end `retrieve_evidence` payload (both singleton and adjacent_span shapes)
- [x] Negative cases each produce at least one validation error
- [x] Runtime invariant helper rejects the schema-passes-but-broken cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)